### PR TITLE
feat: mempool page and pagination

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,6 @@ function App() {
         <Route path="/" element={<MainLayout />}>
           <Route index element={<BlockExplorerPage />} />
           {/* <Route path="*" element={<ErrorPage />} /> */}
-          <Route path="mempool" element={<MempoolPage />} />
           <Route path="vns" element={<VNPage />} />
         </Route>
         <Route path="blocks" element={<PageLayout title="Blocks" />}>
@@ -56,6 +55,9 @@ function App() {
           element={<PageLayout customHeader={<KernelHeader />} />}
         >
           <Route index element={<KernelSearch />} />
+        </Route>
+        <Route path="mempool" element={<PageLayout title="Mempool" />}>
+          <Route index element={<MempoolPage />} />
         </Route>
       </Routes>
     </>

--- a/src/components/StyledComponents.ts
+++ b/src/components/StyledComponents.ts
@@ -27,6 +27,8 @@ import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import Accordion from '@mui/material/Accordion';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
 
 export const AccordionIconButton = styled(IconButton)(({ theme }) => ({
   backgroundColor: theme.palette.divider,
@@ -140,4 +142,19 @@ export const GridDataCell = styled(Box)(({ theme, className }) => ({
   borderBottom: `1px solid ${theme.palette.divider}`,
   fontFamily: "'Courier New', Courier, monospace",
   gridArea: `${className}`,
+}));
+
+export const TransparentButton = styled(Button)(({ theme }) => ({
+  marginTop: theme.spacing(3),
+  marginBottom: theme.spacing(2),
+  height: 56,
+  borderColor: theme.palette.divider,
+  color: 'white',
+  background: theme.palette.divider,
+  textTransform: 'uppercase',
+}));
+
+export const TransparentDivider = styled(Divider)(({ theme }) => ({
+  backgroundColor: theme.palette.divider,
+  background: 'none',
 }));

--- a/src/routes/BlockExplorer.tsx
+++ b/src/routes/BlockExplorer.tsx
@@ -22,7 +22,7 @@
 
 import { GradientPaper } from '../components/StyledComponents';
 import { Grid } from '@mui/material';
-import MempoolTable from './Mempool/MempoolTable';
+import MempoolWidget from './Mempool/MempoolWidget';
 import VNTable from './VNs/VNTable';
 import BlockWidget from './Blocks/BlockWidget';
 import BlockTimesChart from './Charts/BlockTimesChart';
@@ -56,7 +56,7 @@ function BlockExplorerPage() {
           <BlockWidget />
         </GradientPaper>
         <GradientPaper>
-          <MempoolTable />
+          <MempoolWidget />
         </GradientPaper>
       </Grid>
       <Grid

--- a/src/routes/Blocks/BlockTable.tsx
+++ b/src/routes/Blocks/BlockTable.tsx
@@ -26,15 +26,24 @@ import {
   InnerHeading,
   TypographyData,
 } from '../../components/StyledComponents';
-import { Typography, Grid, Divider, ButtonGroup } from '@mui/material';
+import {
+  Typography,
+  Grid,
+  Divider,
+  Box,
+  Button,
+  ButtonGroup,
+  FormControl,
+  MenuItem,
+} from '@mui/material';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
 import {
   toHexString,
   shortenString,
   formatTimestamp,
 } from '../../utils/helpers';
 import { Link } from 'react-router-dom';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
+
 import { useTheme } from '@mui/material/styles';
 import CopyToClipboard from '../../components/CopyToClipboard';
 import { useMediaQuery } from '@mui/material';
@@ -48,7 +57,6 @@ function BlockTable() {
   const { data } = useGetBlocksByParam(firstHeight, blocksPerPage);
   const [prevDisabled, setPrevDisabled] = useState(true);
   const [nextDisabled, setNextDisabled] = useState(false);
-  const [selectedButton, setSelectedButton] = useState(10);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -71,11 +79,10 @@ function BlockTable() {
     }
   }, [firstHeight]);
 
-  const handleChange = (value: number) => () => {
-    setBlocksPerPage(value);
+  const handleNoOfItems = (event: SelectChangeEvent) => {
+    const newValue = parseInt(event.target.value, 10);
+    setBlocksPerPage(newValue);
     setPage(1);
-    setFirstHeight(parseInt(tip));
-    setSelectedButton(value);
   };
 
   const handlePreviousPage = () => {
@@ -281,13 +288,12 @@ function BlockTable() {
           flexDirection: isMobile ? 'column' : 'row',
         }}
       >
-        <Typography variant="caption">
+        <Typography variant="h6">
           Showing blocks {firstHeight - blocksPerPage + 1} - {firstHeight}
         </Typography>
         <ButtonGroup
-          variant="contained"
+          variant="outlined"
           disableElevation
-          size="small"
           style={{ paddingRight: 20, paddingLeft: 20 }}
         >
           <Button
@@ -319,39 +325,23 @@ function BlockTable() {
             gap: theme.spacing(1),
           }}
         >
-          <Typography variant="caption">Rows per page</Typography>
-          <ButtonGroup disableElevation variant="contained" size="small">
-            <Button
-              onClick={handleChange(10)}
-              style={
-                selectedButton === 10
-                  ? { backgroundColor: theme.palette.primary.dark }
-                  : { backgroundColor: theme.palette.primary.main }
-              }
+          <Typography variant="h6">Rows per page</Typography>
+          <FormControl size="small">
+            <Select
+              labelId="rows-per-page"
+              id="rows-per-page"
+              value={blocksPerPage.toString()}
+              onChange={handleNoOfItems}
+              variant="outlined"
+              style={{
+                fontSize: theme.typography.h6.fontSize,
+              }}
             >
-              10
-            </Button>
-            <Button
-              onClick={handleChange(20)}
-              style={
-                selectedButton === 20
-                  ? { backgroundColor: theme.palette.primary.dark }
-                  : { backgroundColor: theme.palette.primary.main }
-              }
-            >
-              20
-            </Button>
-            <Button
-              onClick={handleChange(50)}
-              style={
-                selectedButton === 50
-                  ? { backgroundColor: theme.palette.primary.dark }
-                  : { backgroundColor: theme.palette.primary.main }
-              }
-            >
-              50
-            </Button>
-          </ButtonGroup>
+              <MenuItem value={'10'}>10</MenuItem>
+              <MenuItem value={'20'}>20</MenuItem>
+              <MenuItem value={'50'}>50</MenuItem>
+            </Select>
+          </FormControl>
         </Box>
       </Box>
     </>

--- a/src/routes/Blocks/BlockWidget.tsx
+++ b/src/routes/Blocks/BlockWidget.tsx
@@ -25,6 +25,7 @@ import { useAllBlocks } from '../../api/hooks/useBlocks';
 import {
   InnerHeading,
   TypographyData,
+  TransparentButton,
 } from '../../components/StyledComponents';
 import { Typography, Grid, Divider } from '@mui/material';
 import {
@@ -42,8 +43,8 @@ function BlockWidget() {
   const { data } = useAllBlocks();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const desktopBlocks = 14;
-  const mobileBlocks = 5;
+  const desktopCount = 12;
+  const mobileCount = 5;
 
   function Mobile() {
     const col1 = 4;
@@ -52,7 +53,7 @@ function BlockWidget() {
     return (
       <Grid container spacing={2} pl={2} pr={2}>
         {data?.headers
-          .slice(0, mobileBlocks)
+          .slice(0, mobileCount)
           .map((block: any, index: number) => (
             <Fragment key={index}>
               <Grid item xs={col1}>
@@ -177,7 +178,7 @@ function BlockWidget() {
         </Grid>
         <Grid container spacing={2} pl={2} pr={2} pb={2}>
           {data?.headers
-            .slice(0, desktopBlocks)
+            .slice(0, desktopCount)
             .map((block: any, index: number) => (
               <Fragment key={index}>
                 <Grid item xs={12}>
@@ -247,21 +248,9 @@ function BlockWidget() {
       <InnerHeading>Recent Blocks</InnerHeading>
       {isMobile ? <Mobile /> : <Desktop />}
       <Divider />
-      <Button
-        href="/blocks/"
-        style={{
-          marginTop: theme.spacing(3),
-          marginBottom: theme.spacing(2),
-          borderColor: theme.palette.divider,
-          color: 'white',
-          background: theme.palette.divider,
-          textTransform: 'uppercase',
-        }}
-        variant="text"
-        fullWidth
-      >
+      <TransparentButton href="/blocks/" variant="text" fullWidth>
         View All Blocks
-      </Button>
+      </TransparentButton>
     </>
   );
 }

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -27,7 +27,7 @@ import BlockTimesChart from '../Charts/BlockTimesChart';
 import HashRatesChart from '../Charts/HashRatesChart';
 import POWChart from '../Charts/POWChart';
 import BlockWidget from '../Blocks/BlockWidget';
-import MempoolTable from '../Mempool/MempoolTable';
+import MempoolTable from '../Mempool/MempoolWidget';
 import VNTable from '../VNs/VNTable';
 
 function Home() {

--- a/src/routes/Mempool/MempoolPage.tsx
+++ b/src/routes/Mempool/MempoolPage.tsx
@@ -22,6 +22,7 @@
 
 import { StyledPaper } from '../../components/StyledComponents';
 import { Grid } from '@mui/material';
+// import MempoolWidget from './MempoolWidget';
 import MempoolTable from './MempoolTable';
 
 function MempoolPage() {

--- a/src/routes/Mempool/MempoolWidget.tsx
+++ b/src/routes/Mempool/MempoolWidget.tsx
@@ -20,23 +20,15 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { Fragment, useState } from 'react';
+import { Fragment } from 'react';
 import { useAllBlocks } from '../../api/hooks/useBlocks';
 import {
   InnerHeading,
   TypographyData,
+  TransparentButton,
+  TransparentDivider,
 } from '../../components/StyledComponents';
-import {
-  Typography,
-  Grid,
-  Divider,
-  Alert,
-  Pagination,
-  Box,
-  MenuItem,
-  FormControl,
-} from '@mui/material';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
+import { Typography, Grid, Alert } from '@mui/material';
 import { useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import FetchStatusCheck from '../../components/FetchStatusCheck';
@@ -45,25 +37,11 @@ import CopyToClipboard from '../../components/CopyToClipboard';
 
 function MempoolTable() {
   const { data, isError, isLoading } = useAllBlocks();
-  const [page, setPage] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(10);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-  const totalItems = data?.mempool.length || 0;
-  const totalPages = Math.ceil(totalItems / itemsPerPage);
 
-  const handlePageChange = (
-    _event: React.ChangeEvent<unknown>,
-    value: number
-  ) => {
-    setPage(value);
-  };
-
-  const handleNoOfItems = (event: SelectChangeEvent) => {
-    const newValue = parseInt(event.target.value, 10);
-    setItemsPerPage(newValue);
-    setPage(1);
-  };
+  const desktopCount = 5;
+  const mobileCount = 5;
 
   console.log('data', data?.mempool || 'no data');
 
@@ -73,67 +51,65 @@ function MempoolTable() {
 
     return (
       <Grid container spacing={2} pl={2} pr={2}>
-        {data?.mempool
-          .slice((page - 1) * itemsPerPage, page * itemsPerPage)
-          .map((item: any, index: number) => (
-            <Fragment key={index}>
-              <Grid item xs={col1}>
-                <Typography variant="body2">Excess</Typography>
-              </Grid>
-              <Grid item xs={col2}>
-                <TypographyData>
-                  {' '}
-                  {shortenString(
-                    toHexString(item.transaction.body.signature.data)
-                  )}
-                  <CopyToClipboard
-                    copy={toHexString(item.transaction.body.signature.data)}
-                    key={`${index}-copy`}
-                  />
-                </TypographyData>
-              </Grid>
+        {data?.mempool.slice(0, mobileCount).map((item: any, index: number) => (
+          <Fragment key={index}>
+            <Grid item xs={col1}>
+              <Typography variant="body2">Excess</Typography>
+            </Grid>
+            <Grid item xs={col2}>
+              <TypographyData>
+                {' '}
+                {shortenString(
+                  toHexString(item.transaction.body.signature.data)
+                )}
+                <CopyToClipboard
+                  copy={toHexString(item.transaction.body.signature.data)}
+                  key={`${index}-copy`}
+                />
+              </TypographyData>
+            </Grid>
 
-              <Grid item xs={col1}>
-                <Typography variant="body2">Total Fees</Typography>
-              </Grid>
-              <Grid item xs={col2}>
-                <TypographyData>
-                  {item.transaction.body.total_fees}
-                </TypographyData>
-              </Grid>
+            <Grid item xs={col1}>
+              <Typography variant="body2">Total Fees</Typography>
+            </Grid>
+            <Grid item xs={col2}>
+              <TypographyData>
+                {item.transaction.body.total_fees}
+              </TypographyData>
+            </Grid>
 
-              <Grid item xs={col1}>
-                <Typography variant="body2">Outputs</Typography>
-              </Grid>
-              <Grid item xs={col2}>
-                <TypographyData>
-                  {item.transaction.body.outputs.length}
-                </TypographyData>
-              </Grid>
+            <Grid item xs={col1}>
+              <Typography variant="body2">Outputs</Typography>
+            </Grid>
+            <Grid item xs={col2}>
+              <TypographyData>
+                {item.transaction.body.outputs.length}
+              </TypographyData>
+            </Grid>
 
-              <Grid item xs={col1}>
-                <Typography variant="body2">Kernels</Typography>
-              </Grid>
-              <Grid item xs={col2}>
-                <TypographyData>
-                  {item.transaction.body.kernels.length}
-                </TypographyData>
-              </Grid>
+            <Grid item xs={col1}>
+              <Typography variant="body2">Kernels</Typography>
+            </Grid>
+            <Grid item xs={col2}>
+              <TypographyData>
+                {item.transaction.body.kernels.length}
+              </TypographyData>
+            </Grid>
 
-              <Grid item xs={col1}>
-                <Typography variant="body2">Inputs</Typography>
-              </Grid>
-              <Grid item xs={col2}>
-                <TypographyData>
-                  {item.transaction.body.inputs.length}
-                </TypographyData>
-              </Grid>
+            <Grid item xs={col1}>
+              <Typography variant="body2">Inputs</Typography>
+            </Grid>
+            <Grid item xs={col2}>
+              <TypographyData>
+                {item.transaction.body.inputs.length}
+              </TypographyData>
+            </Grid>
 
-              <Grid item xs={12}>
-                <Divider color={theme.palette.background.paper} />
-              </Grid>
-            </Fragment>
-          ))}
+            <Grid item xs={12}>
+              <TransparentDivider />
+            </Grid>
+          </Fragment>
+        ))}
       </Grid>
     );
   }
@@ -184,11 +160,11 @@ function MempoolTable() {
         </Grid>
         <Grid container spacing={2} pl={2} pr={2} pb={2}>
           {data?.mempool
-            .slice((page - 1) * itemsPerPage, page * itemsPerPage)
+            .slice(0, desktopCount)
             .map((item: any, index: number) => (
               <Fragment key={index}>
                 <Grid item xs={12}>
-                  <Divider color={theme.palette.background.paper} />
+                  <TransparentDivider />
                 </Grid>
                 <Grid item xs={col1} md={col1} lg={col1}>
                   <TypographyData>
@@ -252,7 +228,7 @@ function MempoolTable() {
 
   return (
     <>
-      <InnerHeading>Mempool</InnerHeading>
+      <InnerHeading>Mempool ({data?.mempool.length || '0'})</InnerHeading>
       <FetchStatusCheck
         errorMessage="Error Message"
         isError={isError}
@@ -267,58 +243,9 @@ function MempoolTable() {
       ) : (
         <Desktop />
       )}
-
-      {data?.mempool.length > 0 && !isLoading && !isError && (
-        <>
-          <Divider />
-          <Box
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              padding: theme.spacing(2),
-              gap: theme.spacing(2),
-              flexDirection: isMobile ? 'column' : 'row',
-            }}
-          >
-            <Pagination
-              count={totalPages}
-              page={page}
-              onChange={handlePageChange}
-              showFirstButton
-              showLastButton
-              color="primary"
-              variant="outlined"
-            />
-            <Box
-              style={{
-                display: 'flex',
-                justifyContent: isMobile ? 'center' : 'flex-start',
-                alignItems: 'center',
-                gap: theme.spacing(1),
-              }}
-            >
-              <Typography variant="h6">Rows per page</Typography>
-              <FormControl size="small">
-                <Select
-                  labelId="rows-per-page"
-                  id="rows-per-page"
-                  value={itemsPerPage.toString()}
-                  onChange={handleNoOfItems}
-                  variant="outlined"
-                  style={{
-                    fontSize: theme.typography.h6.fontSize,
-                  }}
-                >
-                  <MenuItem value={'10'}>10</MenuItem>
-                  <MenuItem value={'20'}>20</MenuItem>
-                  <MenuItem value={'50'}>50</MenuItem>
-                </Select>
-              </FormControl>
-            </Box>
-          </Box>
-        </>
-      )}
+      <TransparentButton href="/mempool/" variant="text" fullWidth>
+        View Mempool
+      </TransparentButton>
     </>
   );
 }


### PR DESCRIPTION
Description
---
Added a page for mempool results with pagination.
Changed the mempool widget on the homepage to only display 5 entries, with a click through to the dedicated mempool page if you'd like to view more.

Motivation and Context
---
If there are a lot of transactions in the mempool then everything would display on the homepage in a single table, so I condensed it down a bit.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
The mempool widget is visible on the homepage.
Click on the "View Mempool" button to view more entries.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
