### PR TITLE
fix: hash rate formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3928,9 +3928,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/src/theme/components/Header.tsx
+++ b/src/theme/components/Header.tsx
@@ -35,6 +35,16 @@ import StatsDialog from './StatsDialog';
 import SearchField from './SearchField';
 import { useState } from 'react';
 
+function formatHash(number: number) {
+  const suffixes = ['', 'K', 'M', 'G', 'T', 'P'];
+  let suffixIndex = 0;
+  while (number >= 1000 && suffixIndex < suffixes.length - 1) {
+    number /= 1000;
+    suffixIndex++;
+  }
+  return number.toFixed(1) + ' ' + suffixes[suffixIndex] + 'H';
+}
+
 function Header() {
   const { data } = useAllBlocks();
   const theme = useTheme();
@@ -47,14 +57,11 @@ function Header() {
   );
   const average = sum / values.length;
   const formattedAverageBlockTime = numeral(average).format('0') + 'm';
-
   const formattedBlockHeight = numeral(
     data?.tipInfo.metadata.best_block_height
   ).format('0,0');
-  const formattedMoneroHashRate =
-    numeral(data?.currentMoneroHashRate).format('0.0 a') + 'H';
-  const formattedSha3HashRate =
-    numeral(data?.currentShaHashRate).format('0.0 a') + 'H';
+  const formattedMoneroHashRate = formatHash(data?.currentMoneroHashRate);
+  const formattedSha3HashRate = formatHash(data?.currentShaHashRate);
 
   return (
     <Grid item xs={12} md={12} lg={12}>


### PR DESCRIPTION
Description
---
Change the hash rate formatting for billions to GH and not BH

Motivation and Context
---

How Has This Been Tested?
---
Locally

What process can a PR reviewer use to test or verify this change?
---
If the hash rate exceeds 1 Billion, it should show up as GH

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
