### PR TITLE
fix: current hash rates

### DIFF
--- a/src/theme/components/Header.tsx
+++ b/src/theme/components/Header.tsx
@@ -46,13 +46,20 @@ function Header() {
     (accumulator: number, currentValue: number) => accumulator + currentValue,
     0
   );
+
+  // check for the first non-zero value
+  const latestMoneroHashRate =
+    data?.moneroHashRates?.find((rate: number) => rate !== 0) ?? 0;
+  const latestShaHashRate =
+    data?.shaHashRates?.find((rate: number) => rate !== 0) ?? 0;
+
   const average = sum / values.length;
   const formattedAverageBlockTime = numeral(average).format('0') + 'm';
   const formattedBlockHeight = numeral(
     data?.tipInfo.metadata.best_block_height
   ).format('0,0');
-  const formattedMoneroHashRate = formatHash(data?.currentMoneroHashRate || 0);
-  const formattedSha3HashRate = formatHash(data?.currentShaHashRate || 0);
+  const formattedMoneroHashRate = formatHash(latestMoneroHashRate);
+  const formattedSha3HashRate = formatHash(latestShaHashRate);
 
   return (
     <Grid item xs={12} md={12} lg={12}>


### PR DESCRIPTION
Description
---
Changed the current hash rates to use the first non-zero value from the hash rate arrays

Motivation and Context
---
The top bar wasn't displaying the correct info

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Check the hash rates in the header:

![Screenshot 2024-10-10 at 09 16 12](https://github.com/user-attachments/assets/9a6d3ba3-fb23-419e-b335-d57ace3f9def)


<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
