### PR TITLE
feat: add sticky topbar and reverse charts

### DIFF
--- a/src/components/StyledComponents.ts
+++ b/src/components/StyledComponents.ts
@@ -44,6 +44,7 @@ export const StyledAccordion = styled(Accordion)(({ theme }) => ({
   boxShadow: '1px 5px 28px rgba(35, 11, 73, 0.05)',
   borderRadius: theme.shape.borderRadius,
   marginBottom: theme.spacing(1),
+  border: '1px solid #f8f8f8',
   '&:hover': {
     backgroundColor: '#fafafc',
   },

--- a/src/routes/Blocks/GridItem.tsx
+++ b/src/routes/Blocks/GridItem.tsx
@@ -26,7 +26,6 @@ import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import { shortenString } from '../../utils/helpers';
 import CopyToClipboard from '../../components/CopyToClipboard';
-import { useTheme } from '@mui/material/styles';
 
 function GridItem(
   label: string,
@@ -36,7 +35,6 @@ function GridItem(
   subIndex: number,
   showDivider: boolean
 ) {
-  const theme = useTheme();
   return (
     <Grid
       container
@@ -46,26 +44,10 @@ function GridItem(
         borderTop: showDivider ? `1px solid white` : 'none',
       }}
     >
-      <Grid
-        item
-        xs={12}
-        md={4}
-        lg={4}
-        style={{
-          padding: theme.spacing(2),
-        }}
-      >
+      <Grid item xs={12} md={4} lg={4} p={2}>
         <Typography variant="body2">{label}</Typography>
       </Grid>
-      <Grid
-        item
-        xs={12}
-        md={8}
-        lg={8}
-        style={{
-          padding: theme.spacing(2),
-        }}
-      >
+      <Grid item xs={12} md={8} lg={8} p={2}>
         <TypographyData>
           {copy ? (
             <Fragment>

--- a/src/routes/Charts/HashRates.tsx
+++ b/src/routes/Charts/HashRates.tsx
@@ -79,20 +79,26 @@ const HashRates: React.FC<HashRatesProps> = ({ type }) => {
 
   useEffect(() => {
     const display: Display[] = [];
-    let blockItem = parseInt(tip, 10);
+    const ascendingBlockNumbers: number[] = [];
+    let blockItem = parseInt(tip, 10) - noOfBlocks + 1;
     let hashRates = hashRatesMap[type];
+
+    // Populate ascendingBlockNumbers array
+    for (let i = 0; i < noOfBlocks; i++) {
+      ascendingBlockNumbers.push(blockItem + i);
+    }
+
     for (let i = 1; i <= noOfBlocks; i++) {
       if (hashRates?.[i - 1] !== 0) {
         display.push({
-          blockNumber: blockItem,
+          blockNumber: ascendingBlockNumbers[i - 1],
           hashRate: hashRates?.[i - 1] || 0,
         });
       } else {
         setNoOfBlocks((prevState) => prevState - 1);
       }
-      blockItem = blockItem - 1;
     }
-    setDisplay(display.reverse());
+    setDisplay(display);
   }, [data]);
 
   const option = {

--- a/src/routes/Header/Header.tsx
+++ b/src/routes/Header/Header.tsx
@@ -47,11 +47,8 @@ function Header() {
     0
   );
 
-  // check for the first non-zero value
-  const latestMoneroHashRate =
-    data?.moneroHashRates?.find((rate: number) => rate !== 0) ?? 0;
-  const latestShaHashRate =
-    data?.shaHashRates?.find((rate: number) => rate !== 0) ?? 0;
+  const latestMoneroHashRate = data?.currentMoneroHashRate ?? 0;
+  const latestShaHashRate = data?.currentShaHashRate ?? 0;
 
   const average = sum / values.length;
   const formattedAverageBlockTime = numeral(average).format('0') + 'm';

--- a/src/routes/Header/StickyHeader.tsx
+++ b/src/routes/Header/StickyHeader.tsx
@@ -20,45 +20,50 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { ThemeProvider } from '@mui/material';
-import CssBaseline from '@mui/material/CssBaseline';
-import { Outlet } from 'react-router-dom';
-import Container from '@mui/material/Container';
-import Grid from '@mui/material/Grid';
-import Header from '../routes/Header/Header';
-import StickyHeader from '../routes/Header/StickyHeader';
-import TopBar from '../routes/Header/TopBar';
-import { darkTheme } from './themes';
+import React, { useState, useEffect } from 'react';
+import Box from '@mui/material/Box';
 
-export default function MainLayout() {
-  return (
-    <>
-      <ThemeProvider theme={darkTheme}>
-        <CssBaseline />
-        <Grid container spacing={0} className="main-bg">
-          <StickyHeader>
-            <TopBar />
-            <Header />
-          </StickyHeader>
-          <Container maxWidth="xl">
-            <Outlet />
-          </Container>
-        </Grid>
-      </ThemeProvider>
-      {/* <ThemeProvider theme={lightTheme}>
-        <Container maxWidth="xl">
-          <Grid
-            container
-            spacing={3}
-            style={{
-              paddingTop: lightTheme.spacing(6),
-              paddingBottom: lightTheme.spacing(6),
-            }}
-          >
-            <Outlet />
-          </Grid>
-        </Container>
-      </ThemeProvider> */}
-    </>
-  );
+interface Props {
+  children: React.ReactNode;
 }
+
+const darkBg = 'rgb(25, 14, 43, 0.95)';
+const lightBg = 'rgba(0,0,0,0.1)';
+
+const StickyHeader = ({ children }: Props) => {
+  const [bgColor, setBgColor] = useState(lightBg);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.scrollY > 10) {
+        setBgColor(darkBg);
+      } else {
+        setBgColor(lightBg);
+      }
+    };
+
+    handleScroll();
+
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  return (
+    <Box
+      style={{
+        position: 'sticky',
+        top: 0,
+        width: '100%',
+        backgroundColor: bgColor,
+        transition: 'background-color 0.3s ease',
+        zIndex: 1000,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default StickyHeader;

--- a/src/theme/PageLayout.tsx
+++ b/src/theme/PageLayout.tsx
@@ -26,6 +26,7 @@ import { Outlet } from 'react-router-dom';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Header from '../routes/Header/Header';
+import StickyHeader from '../routes/Header/StickyHeader';
 import TopBar from '../routes/Header/TopBar';
 import { darkTheme, lightTheme } from './themes';
 
@@ -47,27 +48,30 @@ export default function PageLayout({
       <ThemeProvider theme={darkTheme}>
         <CssBaseline />
         <Grid container spacing={0} className="main-bg">
-          <TopBar />
-          <Header />
+          <StickyHeader>
+            <TopBar />
+            <Header />
+          </StickyHeader>
           {customHeader ? (
             customHeader
           ) : (
             <HeaderTitle title={title || ''} subTitle={subTitle || ''} />
           )}
+          <ThemeProvider theme={lightTheme}>
+            <Container
+              maxWidth="xl"
+              style={{
+                paddingTop: lightTheme.spacing(5),
+                paddingBottom: lightTheme.spacing(5),
+                background: lightTheme.palette.background.default,
+              }}
+            >
+              <Grid container spacing={3}>
+                <Outlet />
+              </Grid>
+            </Container>
+          </ThemeProvider>
         </Grid>
-      </ThemeProvider>
-      <ThemeProvider theme={lightTheme}>
-        <Container
-          maxWidth="xl"
-          style={{
-            paddingTop: lightTheme.spacing(5),
-            paddingBottom: lightTheme.spacing(5),
-          }}
-        >
-          <Grid container spacing={3}>
-            <Outlet />
-          </Grid>
-        </Container>
       </ThemeProvider>
     </>
   );


### PR DESCRIPTION
Description
---
Reversed the hashrate charts and changed the hash rate data source that's in the topbar
Made the topbar sticky

Motivation and Context
---
The hashrate charts were displaying the info in reverse
Made the topbar sticky so you don't have to constantly scroll up to see the data in there

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
The hash rate charts are on the homepage
Scroll down to see the topbar stick

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
