### PR TITLE
fix: homepage blocks query

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_ADDRESS=https://textexplore-nextnet.tari.com
+VITE_ADDRESS=https://textexplore.tari.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -3983,9 +3983,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.10.tgz",
-      "integrity": "sha512-f2ueoukYTMI/5kMMT7wW+ol3zL6z6PjN28zYrGKAjnbzXhRXWXPThD3uN6muCp+TbfXaDgGvRuPsg6mwVLaWwQ==",
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
+      "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/Blocks/BlockWidget.tsx
+++ b/src/components/Blocks/BlockWidget.tsx
@@ -21,7 +21,10 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { Fragment } from 'react';
-import { useAllBlocks } from '@services/api/hooks/useBlocks';
+import {
+  useAllBlocks,
+  useGetBlocksByParam,
+} from '@services/api/hooks/useBlocks';
 import { TypographyData, TransparentBg } from '@components/StyledComponents';
 import {
   Typography,
@@ -38,11 +41,14 @@ import CopyToClipboard from '@components/CopyToClipboard';
 import { useMainStore } from '@services/stores/useMainStore';
 
 function BlockWidget() {
-  const { data, isLoading, isError, error } = useAllBlocks();
+  const { data: tipData } = useAllBlocks();
   const theme = useTheme();
+  const tip = tipData?.tipInfo?.metadata?.best_block_height;
+
   const isMobile = useMainStore((state) => state.isMobile);
   const desktopCount = 9;
   const mobileCount = 5;
+  const { data, isLoading, isError, error } = useGetBlocksByParam(tip || 0, 10);
 
   function Mobile() {
     const col1 = 4;

--- a/src/services/api/hooks/useBlocks.tsx
+++ b/src/services/api/hooks/useBlocks.tsx
@@ -50,6 +50,7 @@ export const useGetBlocksByParam = (from: number, limit: number) => {
     onError: (error: apiError) => {
       error;
     },
+    refetchInterval: 120000,
   });
 };
 


### PR DESCRIPTION
Description
---
Changed the query for the homepage recent blocks due to a change in the api

Motivation and Context
---

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved block list display by fetching and displaying the latest 10 blocks based on the current tip height.
- **Chores**
	- Updated service endpoint configuration for network requests.
	- Block data now refreshes automatically every 2 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->