### PR TITLE
fix: blocktime chart and avg block time

### DIFF
--- a/src/components/Blocks/BlockWidget.tsx
+++ b/src/components/Blocks/BlockWidget.tsx
@@ -21,10 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { Fragment } from 'react';
-import {
-  useAllBlocks,
-  useGetBlocksByParam,
-} from '@services/api/hooks/useBlocks';
+import { useAllBlocks } from '@services/api/hooks/useBlocks';
 import { TypographyData, TransparentBg } from '@components/StyledComponents';
 import {
   Typography,
@@ -41,14 +38,11 @@ import CopyToClipboard from '@components/CopyToClipboard';
 import { useMainStore } from '@services/stores/useMainStore';
 
 function BlockWidget() {
-  const { data: tipData } = useAllBlocks();
   const theme = useTheme();
-  const tip = tipData?.tipInfo?.metadata?.best_block_height;
-
+  const { data, isLoading, isError, error } = useAllBlocks();
   const isMobile = useMainStore((state) => state.isMobile);
   const desktopCount = 9;
   const mobileCount = 5;
-  const { data, isLoading, isError, error } = useGetBlocksByParam(tip || 0, 10);
 
   function Mobile() {
     const col1 = 4;

--- a/src/components/Charts/BlockTimes.tsx
+++ b/src/components/Charts/BlockTimes.tsx
@@ -24,20 +24,20 @@ import ReactEcharts from 'echarts-for-react';
 import { useTheme } from '@mui/material/styles';
 import { chartColor } from '@theme/colors';
 import { useAllBlocks } from '@services/api/hooks/useBlocks';
-import { Alert, Skeleton } from '@mui/material';
+import { Alert, Skeleton, Typography, Box } from '@mui/material';
 import { TransparentBg } from '@components/StyledComponents';
 
 interface BlockTimesProps {
-  type: 'RandomX' | 'Sha3';
+  type: 'RandomX' | 'Sha3' | 'All';
+  targetTime: number;
 }
 
-const BlockTimes: React.FC<BlockTimesProps> = ({ type }) => {
+const BlockTimes: React.FC<BlockTimesProps> = ({ type, targetTime }) => {
   const { data, isLoading, isError, error } = useAllBlocks();
   const theme = useTheme();
   const tip = data?.tipInfo?.metadata.best_block_height;
   const noOfBlocks = 60;
   const zoomAmount = 30;
-  const targetTime = 4;
 
   const name = type;
   const colorMap: { [key: string]: string } = {
@@ -126,6 +126,7 @@ const BlockTimes: React.FC<BlockTimesProps> = ({ type }) => {
     yAxis: {
       type: 'value',
       boundaryGap: ['10%', '10%'],
+      min: 0,
       axisLine: {
         lineStyle: {
           color: theme.palette.text.primary,
@@ -158,6 +159,26 @@ const BlockTimes: React.FC<BlockTimesProps> = ({ type }) => {
         type: 'line',
         smooth: false,
         data: blockTimes,
+        markLine: {
+          silent: true,
+          symbol: 'none',
+          lineStyle: {
+            color: theme.palette.grey[300], // Light grey
+            width: 2,
+            type: 'dashed',
+          },
+          label: {
+            show: true,
+            formatter: '',
+            color: theme.palette.grey[600],
+            position: 'start',
+          },
+          data: [
+            {
+              yAxis: targetTime,
+            },
+          ],
+        },
       },
     ],
   };
@@ -176,7 +197,25 @@ const BlockTimes: React.FC<BlockTimesProps> = ({ type }) => {
     return <Skeleton variant="rounded" height={300} />;
   }
 
-  return <ReactEcharts option={option} />;
+  return (
+    <>
+      <Box display="flex" alignItems="center" justifyContent="flex-end">
+        <Box
+          sx={{
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            bgcolor: (theme) => theme.palette.grey[400],
+            mr: 1.2,
+          }}
+        />
+        <Typography variant="body2" color="text.primary">
+          Target Time: {targetTime}m
+        </Typography>
+      </Box>
+      <ReactEcharts option={option} />
+    </>
+  );
 };
 
 export default BlockTimes;

--- a/src/components/Charts/BlockTimes.tsx
+++ b/src/components/Charts/BlockTimes.tsx
@@ -37,6 +37,7 @@ const BlockTimes: React.FC<BlockTimesProps> = ({ type }) => {
   const tip = data?.tipInfo?.metadata.best_block_height;
   const noOfBlocks = 60;
   const zoomAmount = 30;
+  const targetTime = 4;
 
   const name = type;
   const colorMap: { [key: string]: string } = {
@@ -51,8 +52,14 @@ const BlockTimes: React.FC<BlockTimesProps> = ({ type }) => {
     default: data?.blockTimes || [],
   };
 
+  // const color = colorMap[type] || colorMap['default'];
+  // const blockTimes = blockTimesMap[type] || blockTimesMap['default'];
+
   const color = colorMap[type] || colorMap['default'];
-  const blockTimes = blockTimesMap[type] || blockTimesMap['default'];
+  const rawBlockTimes = blockTimesMap[type] || blockTimesMap['default'];
+  const blockTimes = Array.isArray(rawBlockTimes)
+    ? rawBlockTimes.map((blockTime) => targetTime + blockTime)
+    : [];
 
   const blockNumbers = new Array();
   let blockItem = parseInt(tip, 10);

--- a/src/components/Header/StatsBox/StatsBox.tsx
+++ b/src/components/Header/StatsBox/StatsBox.tsx
@@ -11,6 +11,7 @@ interface StatsBoxProps {
 function StatsBox({ variant }: StatsBoxProps) {
   const { data } = useAllBlocks();
   const values = data?.blockTimes || [];
+  const targetTime = 4;
   const sum = values.reduce(
     (accumulator: number, currentValue: number) => accumulator + currentValue,
     0
@@ -20,7 +21,8 @@ function StatsBox({ variant }: StatsBoxProps) {
   const latestShaHashRate = data?.currentShaHashRate ?? 0;
 
   const average = sum / values.length;
-  const formattedAverageBlockTime = numeral(average).format('0') + 'm';
+  const formattedAverageBlockTime =
+    numeral(average + targetTime).format('0') + 'm';
   const formattedBlockHeight = numeral(
     data?.tipInfo.metadata.best_block_height
   ).format('0,0');

--- a/src/components/Header/StatsBox/StatsBox.tsx
+++ b/src/components/Header/StatsBox/StatsBox.tsx
@@ -11,7 +11,7 @@ interface StatsBoxProps {
 function StatsBox({ variant }: StatsBoxProps) {
   const { data } = useAllBlocks();
   const values = data?.blockTimes || [];
-  const targetTime = 4;
+  const targetTime = 2;
   const sum = values.reduce(
     (accumulator: number, currentValue: number) => accumulator + currentValue,
     0

--- a/src/routes/BlockExplorerPage.tsx
+++ b/src/routes/BlockExplorerPage.tsx
@@ -80,10 +80,7 @@ function BlockExplorerPage() {
           <InnerHeading>Block Times (Minutes)</InnerHeading>
           <Grid container spacing={3}>
             <Grid item xs={12}>
-              <BlockTimes type="RandomX" />
-            </Grid>
-            <Grid item xs={12}>
-              <BlockTimes type="Sha3" />
+              <BlockTimes type="All" targetTime={2} />
             </Grid>
           </Grid>
         </GradientPaper>


### PR DESCRIPTION
Description
---
Changed the block times charts to show all blocks
Added a little line for the target time
Added 2 minutes to each block time, because the data coming from the api is returning the difference between the target time and the block time

Motivation and Context
---

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified block times chart that aggregates all types and visually highlights the target block time with a dashed line and legend.
- **Enhancements**
  - The average block time statistic now includes the target time value for improved accuracy and clarity.
  - Simplified block data fetching in the block widget for improved performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->