### PR TITLE
feat: add kernel search

### DIFF
--- a/src/components/Blocks/BlockInfo.tsx
+++ b/src/components/Blocks/BlockInfo.tsx
@@ -22,10 +22,11 @@
 
 import { Fragment } from 'react';
 import { Grid, Divider, Typography } from '@mui/material';
-import { InnerHeading, TypographyData } from '@components/StyledComponents';
+import { TypographyData } from '@components/StyledComponents';
 import { useGetBlockByHeightOrHash } from '@services/api/hooks/useBlocks';
 import { toHexString, shortenString, formatTimestamp } from '@utils/helpers';
 import CopyToClipboard from '@components/CopyToClipboard';
+import InnerHeading from '@components/InnerHeading';
 
 function BlockInfo({ blockHeight }: { blockHeight: any }) {
   const { data } = useGetBlockByHeightOrHash(blockHeight);

--- a/src/components/Blocks/BlockParts.tsx
+++ b/src/components/Blocks/BlockParts.tsx
@@ -21,7 +21,6 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { useState } from 'react';
-import { InnerHeading } from '@components/StyledComponents';
 import Box from '@mui/material/Box';
 import {
   useGetBlockByHeightOrHash,
@@ -34,6 +33,7 @@ import FetchStatusCheck from '@components/FetchStatusCheck';
 import { inputItems } from './Data/Inputs';
 import { outputItems } from './Data/Outputs';
 import { kernelItems } from './Data/Kernels';
+import InnerHeading from '@components/InnerHeading';
 
 function Inputs({
   blockHeight,

--- a/src/components/Blocks/BlockPartsSearch.tsx
+++ b/src/components/Blocks/BlockPartsSearch.tsx
@@ -1,0 +1,326 @@
+import { useState } from 'react';
+import { TextField, Stack, Button, Alert, Typography } from '@mui/material';
+import {
+  useGetBlockByHeightOrHash,
+  useGetPaginatedData,
+} from '@services/api/hooks/useBlocks';
+import Pagination from '@mui/material/Pagination';
+import GenerateAccordion from './GenerateAccordion';
+import FetchStatusCheck from '@components/FetchStatusCheck';
+import { inputItems } from './Data/Inputs';
+import { outputItems } from './Data/Outputs';
+import { kernelItems } from './Data/Kernels';
+import SearchIcon from '@mui/icons-material/Search';
+import IconButton from '@mui/material/IconButton';
+import { useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { kernelSearch } from '../../utils/kernelSearch';
+import InnerHeading from '@components/InnerHeading';
+
+interface KernelsProps {
+  blockHeight: string;
+  type: string;
+  itemsPerPage: number;
+  nonce?: string;
+  signature?: string;
+}
+
+function Kernels({ blockHeight, type, itemsPerPage }: KernelsProps) {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const nonceParams = params.get('nonce');
+  const signatureParams = params.get('signature');
+
+  const [page, setPage] = useState(1);
+  const startIndex = (page - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const { data: blockData } = useGetBlockByHeightOrHash(blockHeight);
+  const {
+    data: paginatedData,
+    isFetching,
+    isError,
+  } = useGetPaginatedData(blockHeight, type, startIndex, endIndex);
+  const { data: allKernelsData } = useGetPaginatedData(
+    blockHeight,
+    'kernels',
+    0,
+    blockData?.body?.kernels_length
+  );
+  const [expanded, setExpanded] = useState<string | false>(false);
+  const [searchValue, setSearchValue] = useState({
+    nonce: '',
+    signature: '',
+  });
+  const [foundIndex, setFoundIndex] = useState<number | null>(null);
+  const [foundPage, setFoundPage] = useState<number | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
+
+  let dataLength = '';
+  switch (type) {
+    case 'inputs':
+      dataLength = 'inputs_length';
+      break;
+    case 'outputs':
+      dataLength = 'outputs_length';
+      break;
+    case 'kernels':
+      dataLength = 'kernels_length';
+      break;
+    default:
+      break;
+  }
+
+  let title = '';
+  switch (type) {
+    case 'inputs':
+      title = 'Input';
+      break;
+    case 'outputs':
+      title = 'Output';
+      break;
+    case 'kernels':
+      title = 'Kernel';
+      break;
+    default:
+      break;
+  }
+
+  const handleChange =
+    (panel: string) => (_: React.SyntheticEvent, isExpanded: boolean) => {
+      setExpanded(isExpanded ? panel : false);
+    };
+
+  const totalItems = blockData?.body[dataLength] || 0;
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const displayedItems = paginatedData?.body.data;
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setSearchValue({
+      ...searchValue,
+      [event.target.name]: value,
+    });
+    setFoundIndex(null);
+  };
+
+  const handleKernelSearch = () => {
+    setHasSearched(true);
+    if (type === 'kernels' && allKernelsData?.body?.data) {
+      const idx = kernelSearch(
+        searchValue.nonce,
+        searchValue.signature,
+        allKernelsData.body.data
+      );
+      setFoundIndex(idx);
+
+      if (idx !== null && idx >= 0) {
+        const kernelPage = Math.floor(idx / itemsPerPage) + 1;
+        setFoundPage(kernelPage);
+        setPage(kernelPage);
+
+        setTimeout(() => {
+          const indexOnPage = idx % itemsPerPage;
+          const foundPanel = `panel${
+            (kernelPage - 1) * itemsPerPage + 1 + indexOnPage
+          }`;
+          setExpanded(foundPanel);
+        }, 0);
+      } else {
+        setFoundPage(null);
+      }
+    }
+  };
+
+  const handleClear = () => {
+    setSearchValue({ nonce: '', signature: '' });
+    setFoundIndex(null);
+    setFoundPage(null);
+    setHasSearched(false);
+    setExpanded(false);
+    setShowSearch(false);
+  };
+
+  useEffect(() => {
+    if (
+      type === 'kernels' &&
+      (nonceParams || signatureParams) &&
+      allKernelsData?.body?.data
+    ) {
+      setShowSearch(true);
+      setSearchValue({
+        nonce: nonceParams || '',
+        signature: signatureParams || '',
+      });
+
+      const idx = kernelSearch(
+        nonceParams || '',
+        signatureParams || '',
+        allKernelsData.body.data
+      );
+      setFoundIndex(idx);
+
+      if (idx !== null && idx >= 0) {
+        const kernelPage = Math.floor(idx / itemsPerPage) + 1;
+        setFoundPage(kernelPage);
+        setPage(kernelPage);
+
+        setTimeout(() => {
+          const indexOnPage = idx % itemsPerPage;
+          const foundPanel = `panel${
+            (kernelPage - 1) * itemsPerPage + 1 + indexOnPage
+          }`;
+          setExpanded(foundPanel);
+        }, 0);
+      } else {
+        setFoundPage(null);
+      }
+      setHasSearched(true);
+    }
+  }, [nonceParams, signatureParams, allKernelsData, type, itemsPerPage]);
+
+  const renderItems = displayedItems?.map((content: any, index: number) => {
+    const adjustedIndex = startIndex + 1 + index;
+    const expandedPanel = `panel${adjustedIndex}`;
+    let items: any[] = [];
+    switch (type) {
+      case 'inputs':
+        items = inputItems(content);
+        break;
+      case 'outputs':
+        items = outputItems(content);
+        break;
+      case 'kernels':
+        items = kernelItems(content);
+        break;
+      default:
+        break;
+    }
+
+    const shouldHighlight =
+      type === 'kernels' &&
+      foundIndex !== null &&
+      foundPage === page &&
+      foundIndex % itemsPerPage === index;
+
+    return (
+      <GenerateAccordion
+        items={items}
+        adjustedIndex={adjustedIndex}
+        expanded={expanded}
+        handleChange={handleChange}
+        expandedPanel={expandedPanel}
+        tabName={title}
+        key={adjustedIndex}
+        isHighlighted={shouldHighlight}
+      />
+    );
+  });
+
+  const handlePageChange = (
+    _event: React.ChangeEvent<unknown>,
+    value: number
+  ) => {
+    setPage(value);
+  };
+
+  if (isFetching || isError) {
+    return (
+      <FetchStatusCheck
+        isLoading={isFetching}
+        isError={isError}
+        errorMessage="Error"
+      />
+    );
+  }
+
+  return (
+    <>
+      <InnerHeading
+        icon={
+          type === 'kernels' ? (
+            <IconButton
+              aria-label={showSearch ? 'Hide search' : 'Show search'}
+              onClick={() => setShowSearch((prev) => !prev)}
+              size="large"
+            >
+              <SearchIcon color={showSearch ? 'primary' : 'inherit'} />
+            </IconButton>
+          ) : null
+        }
+      >
+        {title}s ({totalItems})
+      </InnerHeading>
+      {type === 'kernels' && showSearch && (
+        <Stack gap={1} pb={2}>
+          <Typography variant="body2">
+            Search for a kernel by nonce or signature
+          </Typography>
+          <TextField
+            label="Nonce"
+            placeholder="Search by nonce"
+            name="nonce"
+            variant="outlined"
+            size="small"
+            value={searchValue.nonce}
+            onChange={handleSearchChange}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleKernelSearch();
+              }
+            }}
+            fullWidth
+          />
+          <TextField
+            label="Signature"
+            placeholder="Search by signature"
+            name="signature"
+            variant="outlined"
+            size="small"
+            value={searchValue.signature}
+            onChange={handleSearchChange}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleKernelSearch();
+              }
+            }}
+            fullWidth
+          />
+
+          <Stack direction="row" gap={1} justifyContent="flex-end">
+            <Button onClick={handleClear}>Clear</Button>
+            <Button onClick={handleKernelSearch} variant="contained">
+              Search
+            </Button>
+          </Stack>
+          {foundIndex !== null && foundIndex >= 0 && (
+            <Alert severity="success" sx={{ mt: 1 }} variant="standard">
+              Found in kernel {foundIndex + 1}
+            </Alert>
+          )}
+          {hasSearched && foundIndex === null && (
+            <Alert severity="error" sx={{ mt: 1 }} variant="standard">
+              No matching kernel found
+            </Alert>
+          )}
+        </Stack>
+      )}
+      {renderItems}
+      <Stack justifyContent="center" mt={2} direction="row">
+        {totalItems > itemsPerPage && (
+          <Pagination
+            count={totalPages}
+            page={page}
+            onChange={handlePageChange}
+            showFirstButton
+            showLastButton
+            color="primary"
+            variant="outlined"
+          />
+        )}
+      </Stack>
+    </>
+  );
+}
+
+export default Kernels;

--- a/src/components/Blocks/BlockRewards.tsx
+++ b/src/components/Blocks/BlockRewards.tsx
@@ -21,8 +21,9 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { Typography, Grid } from '@mui/material';
-import { InnerHeading, TypographyData } from '@components/StyledComponents';
+import { TypographyData } from '@components/StyledComponents';
 import { useGetBlockByHeightOrHash } from '@services/api/hooks/useBlocks';
+import InnerHeading from '@components/InnerHeading';
 
 interface BlockRewardsProps {
   blockHeight: string;

--- a/src/components/Blocks/BlockTable.tsx
+++ b/src/components/Blocks/BlockTable.tsx
@@ -25,7 +25,8 @@ import {
   useAllBlocks,
   useGetBlocksByParam,
 } from '@services/api/hooks/useBlocks';
-import { InnerHeading, TypographyData } from '@components/StyledComponents';
+import { TypographyData } from '@components/StyledComponents';
+import InnerHeading from '@components/InnerHeading';
 import {
   Typography,
   Grid,

--- a/src/components/Blocks/GenerateAccordion.tsx
+++ b/src/components/Blocks/GenerateAccordion.tsx
@@ -35,6 +35,7 @@ function GenerateAccordion({
   handleChange,
   expandedPanel,
   tabName,
+  isHighlighted,
 }: {
   items: any;
   adjustedIndex: number;
@@ -44,6 +45,7 @@ function GenerateAccordion({
   ) => (_: React.SyntheticEvent, isExpanded: boolean) => void;
   expandedPanel: string;
   tabName: string;
+  isHighlighted?: boolean;
 }) {
   return (
     <StyledAccordion
@@ -51,6 +53,7 @@ function GenerateAccordion({
       onChange={handleChange(`panel${adjustedIndex}`)}
       elevation={0}
       key={adjustedIndex}
+      isHighlighted={isHighlighted}
     >
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}

--- a/src/components/Blocks/GridItem.tsx
+++ b/src/components/Blocks/GridItem.tsx
@@ -38,7 +38,6 @@ function GridItem(
   return (
     <Grid
       container
-      xs={12}
       style={{
         backgroundColor: subIndex % 2 === 1 ? '' : 'rgba(0, 0, 0, 0.02)',
         borderTop: showDivider ? `1px solid white` : 'none',

--- a/src/components/Charts/BlockTimesChart.tsx
+++ b/src/components/Charts/BlockTimesChart.tsx
@@ -24,7 +24,7 @@ import ReactEcharts from 'echarts-for-react';
 import { useTheme } from '@mui/material/styles';
 import { chartColor } from '@theme/colors';
 import { useAllBlocks } from '@services/api/hooks/useBlocks';
-import { InnerHeading } from '@components/StyledComponents';
+import InnerHeading from '@components/InnerHeading';
 
 const BlockTimes = () => {
   const { data } = useAllBlocks();

--- a/src/components/Charts/HashRatesChart.tsx
+++ b/src/components/Charts/HashRatesChart.tsx
@@ -24,8 +24,8 @@ import ReactEcharts from 'echarts-for-react';
 import { useTheme } from '@mui/material/styles';
 import { chartColor } from '@theme/colors';
 import { useAllBlocks } from '@services/api/hooks/useBlocks';
-import { InnerHeading } from '@components/StyledComponents';
 import { formatHash } from '@utils/helpers';
+import InnerHeading from '@components/InnerHeading';
 
 const HashRates = () => {
   const { data } = useAllBlocks();

--- a/src/components/Header/MinersCTA/MinersCTA.styles.ts
+++ b/src/components/Header/MinersCTA/MinersCTA.styles.ts
@@ -13,7 +13,7 @@ const radarPulse = keyframes`
 `;
 
 export const Wrapper = styled('div')<{
-  $theme: 'light' | 'dark';
+  theme: 'light' | 'dark';
   $noBackground?: boolean;
 }>`
   display: flex;
@@ -31,8 +31,8 @@ export const Wrapper = styled('div')<{
   flex-shrink: 0;
   width: fit-content;
 
-  ${({ $theme }) =>
-    $theme === 'light' &&
+  ${({ theme }) =>
+    theme === 'light' &&
     `
             border: 1px solid rgba(17, 17, 17, 0.2);
             background: rgba(17, 17, 17, 0.05);
@@ -62,7 +62,7 @@ export const TextWrapper = styled('div')`
   position: relative;
 `;
 
-export const Dot = styled('div')<{ $theme: 'light' | 'dark' }>`
+export const Dot = styled('div')<{ theme: 'light' | 'dark' }>`
   width: 11px;
   height: 11px;
   background: linear-gradient(180deg, #0f9 0%, #b0d636 100%);
@@ -88,7 +88,7 @@ export const Dot = styled('div')<{ $theme: 'light' | 'dark' }>`
   }
 `;
 
-export const DotSml = styled('div')<{ $theme: 'light' | 'dark' }>`
+export const DotSml = styled('div')<{ theme: 'light' | 'dark' }>`
   width: 8px;
   height: 8px;
   background: linear-gradient(180deg, #0f9 0%, #b0d636 100%);
@@ -114,7 +114,7 @@ export const DotSml = styled('div')<{ $theme: 'light' | 'dark' }>`
   }
 `;
 
-export const Text = styled('div')<{ $theme: 'light' | 'dark' }>`
+export const Text = styled('div')<{ theme: 'light' | 'dark' }>`
   color: #71ee73;
   font-family: var(--font-poppins), sans-serif;
   font-size: 15px;
@@ -126,8 +126,8 @@ export const Text = styled('div')<{ $theme: 'light' | 'dark' }>`
   transform: translateY(1px);
   white-space: nowrap;
 
-  ${({ $theme }) =>
-    $theme === 'light' &&
+  ${({ theme }) =>
+    theme === 'light' &&
     `
             color: #26764e;
         `}
@@ -142,7 +142,7 @@ export const ButtonWrapper = styled('div')`
   z-index: 1;
 `;
 
-export const Button = styled(Link)<{ $theme: 'light' | 'dark' }>`
+export const Button = styled(Link)<{ theme: 'light' | 'dark' }>`
   position: relative;
   z-index: 1;
   border-radius: 10px;
@@ -189,8 +189,8 @@ export const Button = styled(Link)<{ $theme: 'light' | 'dark' }>`
     }
   }
 
-  ${({ $theme }) =>
-    $theme === 'light' &&
+  ${({ theme }) =>
+    theme === 'light' &&
     `
             background: #000;
             color: #fff;

--- a/src/components/Header/MinersCTA/MinersCTA.tsx
+++ b/src/components/Header/MinersCTA/MinersCTA.tsx
@@ -83,9 +83,9 @@ export default function MinersCTA({
   if (minersOnly) {
     return (
       <TextWrapper>
-        <DotSml $theme={theme} />
+        <DotSml theme={theme as any} />
         <Text
-          $theme={theme}
+          theme={theme as any}
           style={{
             fontSize: '13px',
             letterSpacing: '0.1px',
@@ -119,7 +119,7 @@ export default function MinersCTA({
     return (
       <ButtonWrapper>
         <Button
-          $theme={theme}
+          theme={theme as any}
           href={downloadLink}
           onClick={handleDownloadClick}
           target="_blank"
@@ -133,10 +133,10 @@ export default function MinersCTA({
   return (
     <>
       {!isMobile && <DownloadModal />}
-      <Wrapper $theme={theme} $noBackground={noBackground}>
+      <Wrapper theme={theme as any} $noBackground={noBackground}>
         <TextWrapper>
-          <Dot $theme={theme} />
-          <Text $theme={theme}>
+          <Dot theme={theme as any} />
+          <Text theme={theme as any}>
             <NumberWrapper style={{ width: `${numberWidth}px` }}>
               <span ref={numberRef}>
                 <Suspense fallback={<div>Loading...</div>}>
@@ -156,7 +156,7 @@ export default function MinersCTA({
         </TextWrapper>
         <ButtonWrapper>
           <Button
-            $theme={theme}
+            theme={theme as any}
             href={downloadLink}
             onClick={handleDownloadClick}
             target="_blank"

--- a/src/components/Header/StatsBox/StatsDesktop/StatsItem/StatsItem.styles.ts
+++ b/src/components/Header/StatsBox/StatsDesktop/StatsItem/StatsItem.styles.ts
@@ -9,17 +9,17 @@ export const StyledBox = styled(Box)({
   minWidth: '108px',
 });
 
-export const ValueTypography = styled(Typography)<{ lowerCase?: boolean }>(
-  ({ lowerCase }) => ({
-    textTransform: lowerCase ? 'lowercase' : 'uppercase',
-    fontFamily: 'DrukHeavy',
-    fontSize: '30px',
-    color: '#fff',
-    textAlign: 'center',
-    transition: 'font-size 0.3s ease-in-out',
-    lineHeight: '0.9',
-  })
-);
+export const ValueTypography = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'lowerCase',
+})<{ lowerCase?: boolean }>(({ lowerCase }) => ({
+  textTransform: lowerCase ? 'lowercase' : 'uppercase',
+  fontFamily: 'DrukHeavy',
+  fontSize: '30px',
+  color: '#fff',
+  textAlign: 'center',
+  transition: 'font-size 0.3s ease-in-out',
+  lineHeight: '0.9',
+}));
 
 export const LabelTypography = styled(Typography)({
   fontSize: '11px',

--- a/src/components/InnerHeading.tsx
+++ b/src/components/InnerHeading.tsx
@@ -1,0 +1,36 @@
+import { Typography, Divider, Stack } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+interface InnerHeadingProps {
+  children: React.ReactNode;
+  icon?: React.ReactNode;
+}
+
+const StyledTypography = styled(Typography)(({ theme }) => ({
+  fontSize: theme.typography.h3.fontSize,
+  fontFamily: "'DrukHeavy', sans-serif",
+  textTransform: 'uppercase',
+}));
+
+function InnerHeading({ children, icon }: InnerHeadingProps) {
+  return (
+    <Stack direction="column" gap={1} mb={2}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        gap={1}
+      >
+        <StyledTypography>{children}</StyledTypography>
+        {icon && (
+          <Stack direction="row" alignItems="center" gap={1}>
+            {icon}
+          </Stack>
+        )}
+      </Stack>
+      <Divider />
+    </Stack>
+  );
+}
+
+export default InnerHeading;

--- a/src/components/KernelSearch/BlockTable.tsx
+++ b/src/components/KernelSearch/BlockTable.tsx
@@ -21,7 +21,7 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { useState, Fragment } from 'react';
-import { InnerHeading, TypographyData } from '@components/StyledComponents';
+import { TypographyData } from '@components/StyledComponents';
 import { Typography, Grid, Divider, Pagination } from '@mui/material';
 import { toHexString, shortenString, formatTimestamp } from '@utils/helpers';
 import { Link } from 'react-router-dom';
@@ -29,6 +29,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CopyToClipboard from '@components/CopyToClipboard';
 import { useMainStore } from '@services/stores/useMainStore';
+import InnerHeading from '@components/InnerHeading';
 
 function BlockTable({ data }: { data: any }) {
   const [page, setPage] = useState(1);

--- a/src/components/Mempool/MempoolWidget.tsx
+++ b/src/components/Mempool/MempoolWidget.tsx
@@ -23,7 +23,6 @@
 import { Fragment } from 'react';
 import { useAllBlocks } from '@services/api/hooks/useBlocks';
 import {
-  InnerHeading,
   TypographyData,
   TransparentDivider,
   TransparentBg,
@@ -32,6 +31,7 @@ import { Typography, Grid, Alert, Skeleton, Button, Box } from '@mui/material';
 import { toHexString, shortenString } from '@utils/helpers';
 import CopyToClipboard from '@components/CopyToClipboard';
 import { useMainStore } from '@services/stores/useMainStore';
+import InnerHeading from '@components/InnerHeading';
 
 function MempoolTable() {
   const { data, isError, isLoading, error } = useAllBlocks();

--- a/src/components/StyledComponents.ts
+++ b/src/components/StyledComponents.ts
@@ -30,6 +30,11 @@ import Accordion from '@mui/material/Accordion';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 
+interface StyledAccordionProps {
+  theme?: any;
+  isHighlighted?: boolean;
+}
+
 export const AccordionIconButton = styled(IconButton)(({ theme }) => ({
   backgroundColor: theme.palette.divider,
   color: theme.palette.primary.main,
@@ -39,12 +44,16 @@ export const AccordionIconButton = styled(IconButton)(({ theme }) => ({
   },
 }));
 
-export const StyledAccordion = styled(Accordion)(({ theme }) => ({
+export const StyledAccordion = styled(Accordion, {
+  shouldForwardProp: (prop) => prop !== 'isHighlighted',
+})<StyledAccordionProps>(({ theme, isHighlighted }) => ({
   backgroundColor: theme.palette.background.paper,
-  boxShadow: '1px 5px 28px rgba(35, 11, 73, 0.05)',
+  boxShadow: isHighlighted
+    ? '1px 5px 28px rgba(35, 11, 73, 0.25)'
+    : '1px 5px 28px rgba(35, 11, 73, 0.05)',
   borderRadius: theme.shape.borderRadius,
   marginBottom: theme.spacing(1),
-  border: '1px solid #f8f8f8',
+  border: isHighlighted ? '1px solid #e1e1e1' : '1px solid #f8f8f8',
   '&:hover': {
     backgroundColor: '#fafafc',
   },
@@ -89,14 +98,14 @@ export const PageHeading = styled(Typography)(({ theme }) => ({
   color: theme.palette.text.primary,
 }));
 
-export const InnerHeading = styled(Typography)(({ theme }) => ({
-  fontSize: theme.typography.h3.fontSize,
-  fontFamily: "'DrukHeavy', sans-serif",
-  textTransform: 'uppercase',
-  borderBottom: `1px solid ${theme.palette.divider}`,
-  paddingBottom: theme.spacing(1),
-  marginBottom: theme.spacing(2),
-}));
+// export const InnerHeading = styled(Typography)(({ theme }) => ({
+//   fontSize: theme.typography.h3.fontSize,
+//   fontFamily: "'DrukHeavy', sans-serif",
+//   textTransform: 'uppercase',
+//   borderBottom: `1px solid ${theme.palette.divider}`,
+//   paddingBottom: theme.spacing(1),
+//   marginBottom: theme.spacing(2),
+// }));
 
 export const DataTableCell = styled(TableCell)(() => ({
   fontFamily: "'PoppinsRegular', sans-serif",

--- a/src/components/VNs/VNTable.tsx
+++ b/src/components/VNs/VNTable.tsx
@@ -22,13 +22,10 @@
 
 import { Fragment } from 'react';
 import { useAllBlocks } from '@services/api/hooks/useBlocks';
-import {
-  InnerHeading,
-  TypographyData,
-  TransparentBg,
-} from '@components/StyledComponents';
+import { TypographyData, TransparentBg } from '@components/StyledComponents';
 import { Typography, Grid, Divider, Alert, Skeleton } from '@mui/material';
 import { useMainStore } from '@services/stores/useMainStore';
+import InnerHeading from '@components/InnerHeading';
 
 function VNTable() {
   const { data, isError, isLoading, error } = useAllBlocks();

--- a/src/routes/BlockExplorerPage.tsx
+++ b/src/routes/BlockExplorerPage.tsx
@@ -29,7 +29,7 @@ import BlockTimes from '@components/Charts/BlockTimes';
 import HashRates from '@components/Charts/HashRates';
 import POWChart from '@components/Charts/POWChart';
 import { useTheme } from '@mui/material/styles';
-import { InnerHeading } from '@components/StyledComponents';
+import InnerHeading from '@components/InnerHeading';
 
 function BlockExplorerPage() {
   const theme = useTheme();

--- a/src/routes/BlockPage.tsx
+++ b/src/routes/BlockPage.tsx
@@ -28,6 +28,7 @@ import { useLocation } from 'react-router-dom';
 import { useGetBlockByHeightOrHash } from '@services/api/hooks/useBlocks';
 import FetchStatusCheck from '@components/FetchStatusCheck';
 import BlockParts from '@components/Blocks/BlockParts';
+import BlockPartsSearch from '@components/Blocks/BlockPartsSearch';
 import BlockRewards from '@components/Blocks/BlockRewards';
 
 function BlockPage() {
@@ -87,7 +88,7 @@ function BlockPage() {
           }}
         >
           <GradientPaper>
-            <BlockParts
+            <BlockPartsSearch
               blockHeight={blockHeight}
               type="kernels"
               itemsPerPage={5}

--- a/src/routes/KernelSearchPage.tsx
+++ b/src/routes/KernelSearchPage.tsx
@@ -56,10 +56,12 @@ function KernelsPage() {
     );
   }
 
-  // if (data?.items.length === 1) {
-  //   const blockHeight = data.items[0].block.header.height;
-  //   window.location.replace(`/blocks/${blockHeight}`);
-  // }
+  if (data?.items.length === 1) {
+    const blockHeight = data.items[0].block.header.height;
+    window.location.replace(
+      `/blocks/${blockHeight}?nonce=${noncesParams}&signature=${signaturesParams}`
+    );
+  }
 
   return (
     <Grid item xs={12} md={12} lg={12}>

--- a/src/utils/kernelSearch.ts
+++ b/src/utils/kernelSearch.ts
@@ -1,0 +1,36 @@
+import { toHexString } from '@utils/helpers';
+
+const kernelSearch = (
+  nonce: string,
+  signature: string,
+  kernels: any[]
+): number | null => {
+  if (!kernels) return null;
+
+  const foundIndex = kernels.findIndex((kernel) => {
+    const kernelNonce = toHexString(kernel.excess_sig.public_nonce.data);
+    const kernelSignature = toHexString(kernel.excess_sig.signature.data);
+
+    // Match if either field is provided and matches
+    const nonceMatch = nonce ? kernelNonce.includes(nonce) : false;
+    const signatureMatch = signature
+      ? kernelSignature.includes(signature)
+      : false;
+
+    // If both fields are provided, require both to match; if only one, require that one
+    if (nonce && signature) {
+      return nonceMatch && signatureMatch;
+    }
+    if (nonce) {
+      return nonceMatch;
+    }
+    if (signature) {
+      return signatureMatch;
+    }
+    return false;
+  });
+
+  return foundIndex !== -1 ? foundIndex : null;
+};
+
+export { kernelSearch };


### PR DESCRIPTION
Description
---
Adds the ability to search kernels by nonce or signature
Will also redirect to the relevant block and highlight the kernel if you're coming in from the `/kernel_search` url

Motivation and Context
---
Provides ability to search for kernels

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Click on the following link or click on the search icon next to the Kernels accordion on any block page
https://kernelsearch.tari-block-explore-mainnet.pages.dev/kernel_search?nonces=c80f969825ed961afaeb4cdc5ed33fa7348122296bfe1e079d921bce26fe6c6e&signatures=4b64631184cded72c1a9498d1459ef9f88d27101fc72b44f3d2d8b7d6b2e280e

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->

Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
