### PR TITLE
fix: hashrates display

### DIFF
--- a/src/components/Header/StatsBox/StatsBox.tsx
+++ b/src/components/Header/StatsBox/StatsBox.tsx
@@ -16,9 +16,11 @@ function StatsBox({ variant }: StatsBoxProps) {
     (accumulator: number, currentValue: number) => accumulator + currentValue,
     0
   );
+  const sanitizeValue = (val: string):number => Number(val?.replace(/,/g, ''));
+  const latestMoneroHashRate = sanitizeValue(data?.currentMoneroRandomxHashRate) ?? 0;
+  const latestShaHashRate = sanitizeValue(data?.currentSha3xHashRate) ?? 0;
+  const latestTRXHashRate = sanitizeValue(data?.currentTariRandomxHashRate) ?? 0;
 
-  const latestMoneroHashRate = data?.currentMoneroHashRate ?? 0;
-  const latestShaHashRate = data?.currentShaHashRate ?? 0;
 
   const average = sum / values.length;
   const formattedAverageBlockTime =
@@ -28,17 +30,20 @@ function StatsBox({ variant }: StatsBoxProps) {
   ).format('0,0');
   const formattedMoneroHashRate = formatHash(latestMoneroHashRate);
   const formattedSha3HashRate = formatHash(latestShaHashRate);
+  const formattedTRXHashRate = formatHash(latestTRXHashRate);
 
   return variant === 'mobile' ? (
     <StatsMobile
       moneroHashRate={formattedMoneroHashRate}
       shaHashRate={formattedSha3HashRate}
+      tariRandomXHashRate={formattedTRXHashRate}
       averageBlockTime={formattedAverageBlockTime}
       blockHeight={formattedBlockHeight}
     />
   ) : (
     <StatsDesktop
       moneroHashRate={formattedMoneroHashRate}
+      tariRandomXHashRate={formattedTRXHashRate}
       shaHashRate={formattedSha3HashRate}
       averageBlockTime={formattedAverageBlockTime}
       blockHeight={formattedBlockHeight}

--- a/src/components/Header/StatsBox/StatsDesktop/StatsDesktop.tsx
+++ b/src/components/Header/StatsBox/StatsDesktop/StatsDesktop.tsx
@@ -4,6 +4,7 @@ import StatsItem from './StatsItem/StatsItem';
 interface StatsBoxProps {
   moneroHashRate: string;
   shaHashRate: string;
+  tariRandomXHashRate: string;
   averageBlockTime: string;
   blockHeight: string;
 }
@@ -11,13 +12,15 @@ interface StatsBoxProps {
 function StatsDesktop({
   moneroHashRate,
   shaHashRate,
+  tariRandomXHashRate,
   averageBlockTime,
   blockHeight,
 }: StatsBoxProps) {
   return (
     <Wrapper>
       <StatsItem label="RandomX Hash Rate" value={moneroHashRate} />
-      <StatsItem label="Sha3 Hash Rate" value={shaHashRate} />
+      <StatsItem label="Sha3X Hash Rate" value={shaHashRate} />
+      <StatsItem label="Tari RandomX Hash Rate" value={tariRandomXHashRate} />
       <StatsItem label="Avg Block Time" value={averageBlockTime} lowerCase />
       <StatsItem label="Block Height" value={blockHeight} />
     </Wrapper>

--- a/src/components/Header/StatsBox/StatsMobile/StatsMobile.styles.ts
+++ b/src/components/Header/StatsBox/StatsMobile/StatsMobile.styles.ts
@@ -26,11 +26,11 @@ export const Wrapper = styled(Box)(({ theme }) => ({
 export const StatsWrapperSml = styled(Box)(() => ({
   display: 'flex',
   flexWrap: 'wrap',
-  gap: '8px',
+  gap: '6px',
   justifyContent: 'center',
   width: '100%',
   borderTop: '1px solid rgba(255, 255, 255, 0.1)',
-  padding: '12px 32px',
+  padding: '12px 20px',
   position: 'sticky',
   bottom: '0',
   left: '0',

--- a/src/components/Header/StatsBox/StatsMobile/StatsMobile.tsx
+++ b/src/components/Header/StatsBox/StatsMobile/StatsMobile.tsx
@@ -4,6 +4,7 @@ import StatsItem from './StatsItem/StatsItem';
 interface StatsBoxProps {
   moneroHashRate: string;
   shaHashRate: string;
+  tariRandomXHashRate: string;
   averageBlockTime: string;
   blockHeight: string;
 }
@@ -11,6 +12,7 @@ interface StatsBoxProps {
 function StatsMobile({
   moneroHashRate,
   shaHashRate,
+  tariRandomXHashRate,
   averageBlockTime,
   blockHeight,
 }: StatsBoxProps) {
@@ -30,12 +32,22 @@ function StatsMobile({
         <StatsItem
           label={
             <>
-              Sha3
+              Sha3X
               <br />
               Hash Rate
             </>
           }
           value={shaHashRate}
+        />
+        <StatsItem
+          label={
+            <>
+              Tari RandomX
+              <br />
+              Hash Rate
+            </>
+          }
+          value={tariRandomXHashRate}
         />
         <StatsItem
           label={


### PR DESCRIPTION
Description
---

- add Tari RandomX to header components
- use updated hash rate field names
- sanitize values
- tiny styling changes to make space for the new column on mobile

Motivation and Context
---
- was borked 
How Has This Been Tested?
---
- locally:

<img width="940" alt="image" src="https://github.com/user-attachments/assets/891ee60e-db35-42be-a1ae-1b984c4bc709" />

![optimised_26-05_19-48_489](https://github.com/user-attachments/assets/5a01865a-43ba-4ac7-bffd-689f314858cc)


