### PR TITLE
fix: add Tari RandomX hashrate data to charts

### DIFF
--- a/src/components/Charts/HashRates.tsx
+++ b/src/components/Charts/HashRates.tsx
@@ -30,7 +30,7 @@ import { Alert, Skeleton } from '@mui/material';
 import { TransparentBg } from '@components/StyledComponents';
 
 interface HashRatesProps {
-  type: 'RandomX' | 'Sha3';
+  type: 'RandomX' | 'Sha3'| 'TariRandomX';
 }
 
 interface Display {
@@ -47,12 +47,11 @@ const HashRates: React.FC<HashRatesProps> = ({ type }) => {
   ]);
   const [noOfBlocks, setNoOfBlocks] = useState(180);
   const zoomAmount = 20;
-
   const name = type;
   const colorMap: { [key: string]: string } = {
-    RandomX: chartColor[2],
+    RandomX: chartColor[4],
     Sha3: chartColor[3],
-    default: chartColor[1],
+    default: chartColor[2],
   };
 
   const color = colorMap[type] || colorMap['default'];
@@ -75,8 +74,9 @@ const HashRates: React.FC<HashRatesProps> = ({ type }) => {
   }
 
   const hashRatesMap: { [key: string]: any[] } = {
-    RandomX: data?.moneroHashRates,
-    Sha3: data?.shaHashRates,
+    RandomX: data?.moneroRandomxHashRates,
+    Sha3: data?.sha3xHashRates,
+    TariRandomX: data?.tariRandomxHashRates
   };
 
   useEffect(() => {

--- a/src/components/Charts/HashRatesChart.tsx
+++ b/src/components/Charts/HashRatesChart.tsx
@@ -122,7 +122,7 @@ const HashRates = () => {
         data: data?.moneroHashRates,
       },
       {
-        name: 'Sha 3',
+        name: 'Sha3X',
         type: 'line',
         smooth: true,
         data: data?.shaHashRates,

--- a/src/components/Charts/POWChart.tsx
+++ b/src/components/Charts/POWChart.tsx
@@ -28,51 +28,68 @@ import { Alert, Skeleton } from '@mui/material';
 import { TransparentBg } from '@components/StyledComponents';
 
 interface AlgoSplit {
-  monero10: number;
-  monero20: number;
-  monero50: number;
-  monero100: number;
-  sha10: number;
-  sha20: number;
-  sha50: number;
-  sha100: number;
+  moneroRx10: number;
+  moneroRx20: number;
+  moneroRx50: number;
+  moneroRx100: number;
+  sha3X10: number;
+  sha3X20: number;
+  sha3X50: number;
+  sha3X100: number;
+  tariRx10: number;
+  tariRx20: number;
+  tariRx50: number;
+  tariRx100: number;
 }
 
 const ProofOfWork = () => {
   const theme = useTheme();
   const { data, isError, isLoading, error } = useAllBlocks();
 
-  function calculatePercentage(monero: number, sha: number) {
-    const total = monero + sha;
+  function calculatePercentage(monero: number, sha: number, tari:number) {
+    const total = monero + sha + tari;
     let moneroPercentage = Math.round((monero / total) * 100);
     let shaPercentage = Math.round((sha / total) * 100);
-    const diff = 100 - (moneroPercentage + shaPercentage);
+    let tariPercentage = Math.round((tari / total) * 100);
+    const diff = 100 - (moneroPercentage + shaPercentage + tariPercentage);
     if (diff > 0) {
       moneroPercentage += diff;
     } else if (diff < 0) {
       shaPercentage += diff;
     }
-    return [moneroPercentage, shaPercentage];
+    return [moneroPercentage, shaPercentage, tariPercentage];
   }
-
-  const monero = {
-    10: calculatePercentage(data?.algoSplit.monero10, data?.algoSplit.sha10)[0],
-    20: calculatePercentage(data?.algoSplit.monero20, data?.algoSplit.sha20)[0],
-    50: calculatePercentage(data?.algoSplit.monero50, data?.algoSplit.sha50)[0],
+console.debug(data);
+  const moneroRx = {
+    10: calculatePercentage(data?.algoSplit.moneroRx10, data?.algoSplit.sha3X10, data?.algoSplit.tariRx10)[0],
+    20: calculatePercentage(data?.algoSplit.moneroRx20, data?.algoSplit.sha3X20, data?.algoSplit.tariRx20)[0],
+    50: calculatePercentage(data?.algoSplit.moneroRx50, data?.algoSplit.sha3X50, data?.algoSplit.tariRx50)[0],
     100: calculatePercentage(
-      data?.algoSplit.monero100,
-      data?.algoSplit.sha100
+      data?.algoSplit.moneroRx100,
+      data?.algoSplit.sha3X100,
+      data?.algoSplit.tariRx100,
     )[0],
   };
 
-  const sha = {
-    10: calculatePercentage(data?.algoSplit.monero10, data?.algoSplit.sha10)[1],
-    20: calculatePercentage(data?.algoSplit.monero20, data?.algoSplit.sha20)[1],
-    50: calculatePercentage(data?.algoSplit.monero50, data?.algoSplit.sha50)[1],
+  const sha3X = {
+    10: calculatePercentage(data?.algoSplit.moneroRx10, data?.algoSplit.sha3X10, data?.algoSplit.tariRx10)[1],
+    20: calculatePercentage(data?.algoSplit.moneroRx20, data?.algoSplit.sha3X20, data?.algoSplit.tariRx20)[1],
+    50: calculatePercentage(data?.algoSplit.moneroRx50, data?.algoSplit.sha3X50, data?.algoSplit.tariRx50)[1],
     100: calculatePercentage(
-      data?.algoSplit.monero100,
-      data?.algoSplit.sha100
+      data?.algoSplit.moneroRx100,
+      data?.algoSplit.sha3X100,
+      data?.algoSplit.tariRx100
     )[1],
+  };
+  const tariRx = {
+    10: calculatePercentage(data?.algoSplit.moneroRx10, data?.algoSplit.sha3X10, data?.algoSplit.tariRx10)[2],
+    20: calculatePercentage(data?.algoSplit.moneroRx20, data?.algoSplit.sha3X20, data?.algoSplit.tariRx20)[2],
+    50: calculatePercentage(data?.algoSplit.moneroRx50, data?.algoSplit.sha3X50, data?.algoSplit.tariRx50)[2],
+    100: calculatePercentage(
+      data?.algoSplit.moneroRx100,
+      data?.algoSplit.sha3X100,
+      data?.algoSplit.tariRx100
+    )[2],
   };
 
   const option = {
@@ -83,15 +100,19 @@ const ProofOfWork = () => {
       },
       formatter: function (params: any) {
         const moneroBlocks =
-          data?.algoSplit[`monero${params[0].name}` as keyof AlgoSplit];
+          data?.algoSplit[`moneroRx${params[0].name}` as keyof AlgoSplit];
         const shaBlocks =
-          data?.algoSplit[`sha${params[0].name}` as keyof AlgoSplit];
+          data?.algoSplit[`sha3X${params[0].name}` as keyof AlgoSplit];
+        const tariBlocks =
+          data?.algoSplit[`tariRx${params[0].name}` as keyof AlgoSplit];
         const moneroColor = params[0].color;
         const shaColor = params[1].color;
+        const tariColor = params[2].color;
         return `
           <b>In the last ${params[0].name} blocks:</b><br />
           <span style="color:${moneroColor};"></span>RandomX: ${moneroBlocks} blocks (${params[0].value}%)<br />
           <span style="color:${shaColor};"></span>Sha 3: ${shaBlocks} blocks (${params[1].value}%)
+          <span style="color:${tariColor};"></span>Tari RandomX: ${tariBlocks} blocks (${params[2].value}%)
         `;
       },
     },
@@ -101,7 +122,7 @@ const ProofOfWork = () => {
       },
       bottom: 10,
     },
-    color: [chartColor[2], chartColor[3]],
+    color: [chartColor[4], chartColor[3], chartColor[2]],
     grid: {
       left: '2%',
       right: '2%',
@@ -153,7 +174,7 @@ const ProofOfWork = () => {
         emphasis: {
           focus: 'series',
         },
-        data: [monero[100], monero[50], monero[20], monero[10]],
+        data: [moneroRx[100], moneroRx[50], moneroRx[20], moneroRx[10]],
       },
       {
         name: 'Sha 3',
@@ -166,7 +187,20 @@ const ProofOfWork = () => {
         emphasis: {
           focus: 'series',
         },
-        data: [sha[100], sha[50], sha[20], sha[10]],
+        data: [sha3X[100], sha3X[50], sha3X[20], sha3X[10]],
+      },
+      {
+        name: 'Tari RandomX',
+        type: 'bar',
+        stack: 'total',
+        label: {
+          show: true,
+          formatter: `{c}%`,
+        },
+        emphasis: {
+          focus: 'series',
+        },
+        data: [tariRx[100], tariRx[50], tariRx[20], tariRx[10]],
       },
     ],
   };

--- a/src/components/Charts/POWChart.tsx
+++ b/src/components/Charts/POWChart.tsx
@@ -59,7 +59,7 @@ const ProofOfWork = () => {
     }
     return [moneroPercentage, shaPercentage, tariPercentage];
   }
-console.debug(data);
+
   const moneroRx = {
     10: calculatePercentage(data?.algoSplit.moneroRx10, data?.algoSplit.sha3X10, data?.algoSplit.tariRx10)[0],
     20: calculatePercentage(data?.algoSplit.moneroRx20, data?.algoSplit.sha3X20, data?.algoSplit.tariRx20)[0],

--- a/src/routes/BlockExplorerPage.tsx
+++ b/src/routes/BlockExplorerPage.tsx
@@ -93,6 +93,9 @@ function BlockExplorerPage() {
             <Grid item xs={12}>
               <HashRates type="Sha3" />
             </Grid>
+            <Grid item xs={12}>
+              <HashRates type="TariRandomX" />
+            </Grid>
           </Grid>
         </GradientPaper>
         <GradientPaper>


### PR DESCRIPTION
Description
---

- add Tari RandomX values to PoW chart & add its own hashrate graph


How Has This Been Tested?
---

- locally:
![optimised_26-05_20-52_492](https://github.com/user-attachments/assets/9abb724e-58a9-4f3a-8292-eb585b7d0ff8)
![optimised_26-05_20-53_493](https://github.com/user-attachments/assets/37844104-2e4c-4dbd-b3a9-2cb89600a68f)

