### PR TITLE
feat: add search by payref

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,8 @@ import KernelHeader from '@components/KernelSearch/KernelHeader';
 import { useMediaQuery, useTheme } from '@mui/material';
 import { useMainStore } from '@services/stores/useMainStore';
 import { useEffect } from 'react';
+import PayRefSearchPage from '@routes/PayRefSearchPage';
+import PayRefHeader from '@components/PayRefSearch/PayRefHeader';
 
 function App() {
   const theme = useTheme();
@@ -68,6 +70,12 @@ function App() {
           element={<PageLayout customHeader={<KernelHeader />} />}
         >
           <Route index element={<KernelSearch />} />
+        </Route>
+        <Route
+          path="search_outputs_by_payref"
+          element={<PageLayout customHeader={<PayRefHeader />} />}
+        >
+          <Route index element={<PayRefSearchPage />} />
         </Route>
         <Route path="mempool" element={<PageLayout title="Mempool" />}>
           <Route index element={<MempoolPage />} />

--- a/src/components/Blocks/Data/Outputs.ts
+++ b/src/components/Blocks/Data/Outputs.ts
@@ -25,6 +25,11 @@ import { toHexString } from '@utils/helpers';
 export const outputItems = (content: any) => {
   const items = [
     {
+      label: 'Payment Reference',
+      value: toHexString(content.payment_reference.data),
+      copy: true,
+    },
+    {
       label: 'Features',
       copy: false,
       children: [
@@ -107,11 +112,6 @@ export const outputItems = (content: any) => {
       label: 'Covenant Version',
       value: content.covenant.data,
       copy: false,
-    },
-    {
-      label: 'Payment Reference',
-      value: toHexString(content.payment_reference.data),
-      copy: true,
     },
     {
       label: 'Encrypted Data',

--- a/src/components/Blocks/Data/Outputs.ts
+++ b/src/components/Blocks/Data/Outputs.ts
@@ -109,6 +109,11 @@ export const outputItems = (content: any) => {
       copy: false,
     },
     {
+      label: 'Payment Reference',
+      value: toHexString(content.payment_reference.data),
+      copy: true,
+    },
+    {
       label: 'Encrypted Data',
       value: toHexString(content.encrypted_data.data),
       copy: true,

--- a/src/components/Blocks/GenerateAccordion.tsx
+++ b/src/components/Blocks/GenerateAccordion.tsx
@@ -21,12 +21,15 @@
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import { Fragment } from 'react';
-import { StyledAccordion } from '@components/StyledComponents';
+import {
+  StyledAccordion,
+  StyledAccordionSummary,
+} from '@components/StyledComponents';
 import AccordionDetails from '@mui/material/AccordionDetails';
-import AccordionSummary from '@mui/material/AccordionSummary';
 import Typography from '@mui/material/Typography';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import GridItem from './GridItem';
+import { IoCheckmarkCircle } from 'react-icons/io5';
 
 function GenerateAccordion({
   items,
@@ -55,15 +58,32 @@ function GenerateAccordion({
       key={adjustedIndex}
       isHighlighted={isHighlighted}
     >
-      <AccordionSummary
-        expandIcon={<ExpandMoreIcon />}
+      <StyledAccordionSummary
+        expandIcon={
+          <ExpandMoreIcon
+            style={{
+              color: isHighlighted ? '#fff' : 'inherit',
+              transition: 'color 0.3s ease',
+            }}
+          />
+        }
         aria-controls={expandedPanel + '-content'}
         id={expandedPanel + '-header'}
+        isHighlighted={isHighlighted}
+        expanded={expanded === `panel${adjustedIndex}`}
       >
-        <Typography variant="h5">
+        <Typography
+          variant="h5"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+          }}
+        >
+          {isHighlighted && <IoCheckmarkCircle size="22" color="#B0D636" />}{' '}
           {tabName} {adjustedIndex}
         </Typography>
-      </AccordionSummary>
+      </StyledAccordionSummary>
       <AccordionDetails
         style={{
           padding: 0,

--- a/src/components/Blocks/Kernels.tsx
+++ b/src/components/Blocks/Kernels.tsx
@@ -200,7 +200,7 @@ function Kernels({ blockHeight, type, itemsPerPage }: KernelsProps) {
           expanded={expanded}
           handleChange={handleChange}
           expandedPanel={expandedPanel}
-          tabName={title}
+          tabName={`Found in ${title}`}
           key={adjustedIndex}
           isHighlighted={true}
         />
@@ -324,11 +324,11 @@ function Kernels({ blockHeight, type, itemsPerPage }: KernelsProps) {
               Search
             </Button>
           </Stack>
-          {foundIndex !== null && foundIndex >= 0 && (
+          {/* {foundIndex !== null && foundIndex >= 0 && (
             <Alert severity="success" sx={{ mt: 1 }} variant="standard">
               Found in kernel {foundIndex + 1}
             </Alert>
-          )}
+          )} */}
           {hasSearched && foundIndex === null && (
             <Alert severity="error" sx={{ mt: 1 }} variant="standard">
               No matching kernel found

--- a/src/components/Blocks/Kernels.tsx
+++ b/src/components/Blocks/Kernels.tsx
@@ -14,7 +14,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import IconButton from '@mui/material/IconButton';
 import { useLocation } from 'react-router-dom';
 import { useEffect } from 'react';
-import { kernelSearch } from '../../utils/kernelSearch';
+import { kernelSearch } from '@/utils/searchFunctions';
 import InnerHeading from '@components/InnerHeading';
 
 interface KernelsProps {

--- a/src/components/Blocks/Kernels.tsx
+++ b/src/components/Blocks/Kernels.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { TextField, Stack, Button, Alert, Typography } from '@mui/material';
 import {
   useGetBlockByHeightOrHash,
@@ -13,7 +13,6 @@ import { kernelItems } from './Data/Kernels';
 import SearchIcon from '@mui/icons-material/Search';
 import IconButton from '@mui/material/IconButton';
 import { useLocation } from 'react-router-dom';
-import { useEffect } from 'react';
 import { kernelSearch } from '@/utils/searchFunctions';
 import InnerHeading from '@components/InnerHeading';
 
@@ -179,43 +178,75 @@ function Kernels({ blockHeight, type, itemsPerPage }: KernelsProps) {
     }
   }, [nonceParams, signatureParams, allKernelsData, type, itemsPerPage]);
 
-  const renderItems = displayedItems?.map((content: any, index: number) => {
-    const adjustedIndex = startIndex + 1 + index;
-    const expandedPanel = `panel${adjustedIndex}`;
-    let items: any[] = [];
-    switch (type) {
-      case 'inputs':
-        items = inputItems(content);
-        break;
-      case 'outputs':
-        items = outputItems(content);
-        break;
-      case 'kernels':
-        items = kernelItems(content);
-        break;
-      default:
-        break;
+  let renderItems;
+
+  if (
+    type === 'kernels' &&
+    foundIndex !== null &&
+    foundIndex >= 0 &&
+    foundPage === page
+  ) {
+    const indexOnPage = foundIndex % itemsPerPage;
+    const content = displayedItems?.[indexOnPage];
+    if (content) {
+      const adjustedIndex = startIndex + 1 + indexOnPage;
+      const expandedPanel = `panel${adjustedIndex}`;
+      const items = kernelItems(content);
+
+      renderItems = (
+        <GenerateAccordion
+          items={items}
+          adjustedIndex={adjustedIndex}
+          expanded={expanded}
+          handleChange={handleChange}
+          expandedPanel={expandedPanel}
+          tabName={title}
+          key={adjustedIndex}
+          isHighlighted={true}
+        />
+      );
+    } else {
+      renderItems = null;
     }
+  } else {
+    renderItems = displayedItems?.map((content: any, index: number) => {
+      const adjustedIndex = startIndex + 1 + index;
+      const expandedPanel = `panel${adjustedIndex}`;
+      let items: any[] = [];
+      switch (type) {
+        case 'inputs':
+          items = inputItems(content);
+          break;
+        case 'outputs':
+          items = outputItems(content);
+          break;
+        case 'kernels':
+          items = kernelItems(content);
+          break;
+        default:
+          break;
+      }
 
-    const shouldHighlight =
-      type === 'kernels' &&
-      foundIndex !== null &&
-      foundPage === page &&
-      foundIndex % itemsPerPage === index;
+      const shouldHighlight =
+        type === 'kernels' &&
+        foundIndex !== null &&
+        foundPage === page &&
+        foundIndex % itemsPerPage === index;
 
-    return (
-      <GenerateAccordion
-        items={items}
-        adjustedIndex={adjustedIndex}
-        expanded={expanded}
-        handleChange={handleChange}
-        expandedPanel={expandedPanel}
-        tabName={title}
-        key={adjustedIndex}
-        isHighlighted={shouldHighlight}
-      />
-    );
-  });
+      return (
+        <GenerateAccordion
+          items={items}
+          adjustedIndex={adjustedIndex}
+          expanded={expanded}
+          handleChange={handleChange}
+          expandedPanel={expandedPanel}
+          tabName={title}
+          key={adjustedIndex}
+          isHighlighted={shouldHighlight}
+        />
+      );
+    });
+  }
 
   const handlePageChange = (
     _event: React.ChangeEvent<unknown>,
@@ -307,17 +338,23 @@ function Kernels({ blockHeight, type, itemsPerPage }: KernelsProps) {
       )}
       {renderItems}
       <Stack justifyContent="center" mt={2} direction="row">
-        {totalItems > itemsPerPage && (
-          <Pagination
-            count={totalPages}
-            page={page}
-            onChange={handlePageChange}
-            showFirstButton
-            showLastButton
-            color="primary"
-            variant="outlined"
-          />
-        )}
+        {totalItems > itemsPerPage &&
+          !(
+            type === 'kernels' &&
+            foundIndex !== null &&
+            foundIndex >= 0 &&
+            foundPage === page
+          ) && (
+            <Pagination
+              count={totalPages}
+              page={page}
+              onChange={handlePageChange}
+              showFirstButton
+              showLastButton
+              color="primary"
+              variant="outlined"
+            />
+          )}
       </Stack>
     </>
   );

--- a/src/components/Blocks/Outputs.tsx
+++ b/src/components/Blocks/Outputs.tsx
@@ -184,7 +184,7 @@ function Outputs({ blockHeight, type, itemsPerPage }: OutputsProps) {
           expanded={expanded}
           handleChange={handleChange}
           expandedPanel={expandedPanel}
-          tabName={title}
+          tabName={`Found in ${title}`}
           key={adjustedIndex}
           isHighlighted={true}
         />
@@ -193,7 +193,6 @@ function Outputs({ blockHeight, type, itemsPerPage }: OutputsProps) {
       renderItems = null;
     }
   } else {
-    // Show all items as before
     renderItems = displayedItems?.map((content: any, index: number) => {
       const adjustedIndex = startIndex + 1 + index;
       const expandedPanel = `panel${adjustedIndex}`;
@@ -294,11 +293,11 @@ function Outputs({ blockHeight, type, itemsPerPage }: OutputsProps) {
               Search
             </Button>
           </Stack>
-          {foundIndex !== null && foundIndex >= 0 && (
+          {/* {foundIndex !== null && foundIndex >= 0 && (
             <Alert severity="success" sx={{ mt: 1 }} variant="standard">
               Found in output {foundIndex + 1}
             </Alert>
-          )}
+          )} */}
           {hasSearched && foundIndex === null && (
             <Alert severity="error" sx={{ mt: 1 }} variant="standard">
               No matching output found

--- a/src/components/Blocks/Outputs.tsx
+++ b/src/components/Blocks/Outputs.tsx
@@ -59,7 +59,14 @@ function Outputs({ blockHeight, type, itemsPerPage }: OutputsProps) {
       foundPage === page &&
       expanded
     ) {
-      foundRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      const el = foundRef.current;
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        const scrollTop =
+          window.pageYOffset || document.documentElement.scrollTop;
+        const top = rect.top + scrollTop - 150;
+        window.scrollTo({ top, behavior: 'smooth' });
+      }
     }
   }, [foundIndex, foundPage, page, expanded]);
 

--- a/src/components/Blocks/Outputs.tsx
+++ b/src/components/Blocks/Outputs.tsx
@@ -1,0 +1,295 @@
+import { useState } from 'react';
+import { TextField, Stack, Button, Alert, Typography } from '@mui/material';
+import {
+  useGetBlockByHeightOrHash,
+  useGetPaginatedData,
+} from '@services/api/hooks/useBlocks';
+import Pagination from '@mui/material/Pagination';
+import GenerateAccordion from './GenerateAccordion';
+import FetchStatusCheck from '@components/FetchStatusCheck';
+import { inputItems } from './Data/Inputs';
+import { outputItems } from './Data/Outputs';
+import { kernelItems } from './Data/Kernels';
+import SearchIcon from '@mui/icons-material/Search';
+import IconButton from '@mui/material/IconButton';
+import { useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { payrefSearch } from '@utils/searchFunctions';
+import InnerHeading from '@components/InnerHeading';
+
+interface OutputsProps {
+  blockHeight: string;
+  type: string;
+  itemsPerPage: number;
+  payref?: string;
+}
+
+function Outputs({ blockHeight, type, itemsPerPage }: OutputsProps) {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const payrefParams = params.get('payref');
+
+  const [page, setPage] = useState(1);
+  const startIndex = (page - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const { data: blockData } = useGetBlockByHeightOrHash(blockHeight);
+  const {
+    data: paginatedData,
+    isFetching,
+    isError,
+  } = useGetPaginatedData(blockHeight, type, startIndex, endIndex);
+  const { data: outputsData } = useGetPaginatedData(
+    blockHeight,
+    'outputs',
+    0,
+    blockData?.body?.outputs_length
+  );
+  const [expanded, setExpanded] = useState<string | false>(false);
+  const [searchValue, setSearchValue] = useState({
+    payref: '',
+  });
+  const [foundIndex, setFoundIndex] = useState<number | null>(null);
+  const [foundPage, setFoundPage] = useState<number | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
+
+  let dataLength = '';
+  switch (type) {
+    case 'inputs':
+      dataLength = 'inputs_length';
+      break;
+    case 'outputs':
+      dataLength = 'outputs_length';
+      break;
+    case 'kernels':
+      dataLength = 'kernels_length';
+      break;
+    default:
+      break;
+  }
+
+  let title = '';
+  switch (type) {
+    case 'inputs':
+      title = 'Input';
+      break;
+    case 'outputs':
+      title = 'Output';
+      break;
+    case 'kernels':
+      title = 'Kernel';
+      break;
+    default:
+      break;
+  }
+
+  const handleChange =
+    (panel: string) => (_: React.SyntheticEvent, isExpanded: boolean) => {
+      setExpanded(isExpanded ? panel : false);
+    };
+
+  const totalItems = blockData?.body[dataLength] || 0;
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const displayedItems = paginatedData?.body.data;
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setSearchValue({
+      ...searchValue,
+      [event.target.name]: value,
+    });
+    setFoundIndex(null);
+  };
+
+  const handleOutputsSearch = () => {
+    setHasSearched(true);
+    if (type === 'outputs' && outputsData?.body?.data) {
+      const idx = payrefSearch(searchValue.payref, outputsData.body.data);
+      setFoundIndex(idx);
+
+      if (idx !== null && idx >= 0) {
+        const outputPage = Math.floor(idx / itemsPerPage) + 1;
+        setFoundPage(outputPage);
+        setPage(outputPage);
+
+        setTimeout(() => {
+          const indexOnPage = idx % itemsPerPage;
+          const foundPanel = `panel${
+            (outputPage - 1) * itemsPerPage + 1 + indexOnPage
+          }`;
+          setExpanded(foundPanel);
+        }, 0);
+      } else {
+        setFoundPage(null);
+      }
+    }
+  };
+
+  const handleClear = () => {
+    setSearchValue({ payref: '' });
+    setFoundIndex(null);
+    setFoundPage(null);
+    setHasSearched(false);
+    setExpanded(false);
+    setShowSearch(false);
+  };
+
+  useEffect(() => {
+    if (type === 'outputs' && payrefParams && outputsData?.body?.data) {
+      setShowSearch(true);
+      setSearchValue({
+        payref: payrefParams || '',
+      });
+
+      const idx = payrefSearch(payrefParams || '', outputsData.body.data);
+      setFoundIndex(idx);
+
+      if (idx !== null && idx >= 0) {
+        const outputPage = Math.floor(idx / itemsPerPage) + 1;
+        setFoundPage(outputPage);
+        setPage(outputPage);
+
+        setTimeout(() => {
+          const indexOnPage = idx % itemsPerPage;
+          const foundPanel = `panel${
+            (outputPage - 1) * itemsPerPage + 1 + indexOnPage
+          }`;
+          setExpanded(foundPanel);
+        }, 0);
+      } else {
+        setFoundPage(null);
+      }
+      setHasSearched(true);
+    }
+  }, [payrefParams, outputsData, type, itemsPerPage]);
+
+  const renderItems = displayedItems?.map((content: any, index: number) => {
+    const adjustedIndex = startIndex + 1 + index;
+    const expandedPanel = `panel${adjustedIndex}`;
+    let items: any[] = [];
+    switch (type) {
+      case 'inputs':
+        items = inputItems(content);
+        break;
+      case 'outputs':
+        items = outputItems(content);
+        break;
+      case 'kernels':
+        items = kernelItems(content);
+        break;
+      default:
+        break;
+    }
+
+    const shouldHighlight =
+      type === 'outputs' &&
+      foundIndex !== null &&
+      foundPage === page &&
+      foundIndex % itemsPerPage === index;
+
+    return (
+      <GenerateAccordion
+        items={items}
+        adjustedIndex={adjustedIndex}
+        expanded={expanded}
+        handleChange={handleChange}
+        expandedPanel={expandedPanel}
+        tabName={title}
+        key={adjustedIndex}
+        isHighlighted={shouldHighlight}
+      />
+    );
+  });
+
+  const handlePageChange = (
+    _event: React.ChangeEvent<unknown>,
+    value: number
+  ) => {
+    setPage(value);
+  };
+
+  if (isFetching || isError) {
+    return (
+      <FetchStatusCheck
+        isLoading={isFetching}
+        isError={isError}
+        errorMessage="Error"
+      />
+    );
+  }
+
+  return (
+    <>
+      <InnerHeading
+        icon={
+          type === 'outputs' ? (
+            <IconButton
+              aria-label={showSearch ? 'Hide search' : 'Show search'}
+              onClick={() => setShowSearch((prev) => !prev)}
+              size="large"
+            >
+              <SearchIcon color={showSearch ? 'primary' : 'inherit'} />
+            </IconButton>
+          ) : null
+        }
+      >
+        {title}s ({totalItems})
+      </InnerHeading>
+      {type === 'outputs' && showSearch && (
+        <Stack gap={1} pb={2}>
+          <Typography variant="body2">
+            Search by Payment Reference (PayRef)
+          </Typography>
+          <TextField
+            label="Payment Reference"
+            placeholder="Enter 64-character PayRef hash"
+            name="payref"
+            variant="outlined"
+            size="small"
+            value={searchValue.payref}
+            onChange={handleSearchChange}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleOutputsSearch();
+              }
+            }}
+            fullWidth
+          />
+
+          <Stack direction="row" gap={1} justifyContent="flex-end">
+            <Button onClick={handleClear}>Clear</Button>
+            <Button onClick={handleOutputsSearch} variant="contained">
+              Search
+            </Button>
+          </Stack>
+          {foundIndex !== null && foundIndex >= 0 && (
+            <Alert severity="success" sx={{ mt: 1 }} variant="standard">
+              Found in output {foundIndex + 1}
+            </Alert>
+          )}
+          {hasSearched && foundIndex === null && (
+            <Alert severity="error" sx={{ mt: 1 }} variant="standard">
+              No matching output found
+            </Alert>
+          )}
+        </Stack>
+      )}
+      {renderItems}
+      <Stack justifyContent="center" mt={2} direction="row">
+        {totalItems > itemsPerPage && (
+          <Pagination
+            count={totalPages}
+            page={page}
+            onChange={handlePageChange}
+            showFirstButton
+            showLastButton
+            color="primary"
+            variant="outlined"
+          />
+        )}
+      </Stack>
+    </>
+  );
+}
+
+export default Outputs;

--- a/src/components/Blocks/OutputsShowMultiple.tsx
+++ b/src/components/Blocks/OutputsShowMultiple.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { TextField, Stack, Button, Alert, Typography } from '@mui/material';
 import {
   useGetBlockByHeightOrHash,
@@ -13,6 +13,7 @@ import { kernelItems } from './Data/Kernels';
 import SearchIcon from '@mui/icons-material/Search';
 import IconButton from '@mui/material/IconButton';
 import { useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
 import { payrefSearch } from '@utils/searchFunctions';
 import InnerHeading from '@components/InnerHeading';
 
@@ -162,76 +163,43 @@ function Outputs({ blockHeight, type, itemsPerPage }: OutputsProps) {
     }
   }, [payrefParams, outputsData, type, itemsPerPage]);
 
-  let renderItems;
-
-  if (
-    type === 'outputs' &&
-    foundIndex !== null &&
-    foundIndex >= 0 &&
-    foundPage === page
-  ) {
-    const indexOnPage = foundIndex % itemsPerPage;
-    const content = displayedItems?.[indexOnPage];
-    if (content) {
-      const adjustedIndex = startIndex + 1 + indexOnPage;
-      const expandedPanel = `panel${adjustedIndex}`;
-      const items = outputItems(content);
-
-      renderItems = (
-        <GenerateAccordion
-          items={items}
-          adjustedIndex={adjustedIndex}
-          expanded={expanded}
-          handleChange={handleChange}
-          expandedPanel={expandedPanel}
-          tabName={title}
-          key={adjustedIndex}
-          isHighlighted={true}
-        />
-      );
-    } else {
-      renderItems = null;
+  const renderItems = displayedItems?.map((content: any, index: number) => {
+    const adjustedIndex = startIndex + 1 + index;
+    const expandedPanel = `panel${adjustedIndex}`;
+    let items: any[] = [];
+    switch (type) {
+      case 'inputs':
+        items = inputItems(content);
+        break;
+      case 'outputs':
+        items = outputItems(content);
+        break;
+      case 'kernels':
+        items = kernelItems(content);
+        break;
+      default:
+        break;
     }
-  } else {
-    // Show all items as before
-    renderItems = displayedItems?.map((content: any, index: number) => {
-      const adjustedIndex = startIndex + 1 + index;
-      const expandedPanel = `panel${adjustedIndex}`;
-      let items: any[] = [];
-      switch (type) {
-        case 'inputs':
-          items = inputItems(content);
-          break;
-        case 'outputs':
-          items = outputItems(content);
-          break;
-        case 'kernels':
-          items = kernelItems(content);
-          break;
-        default:
-          break;
-      }
 
-      const shouldHighlight =
-        type === 'outputs' &&
-        foundIndex !== null &&
-        foundPage === page &&
-        foundIndex % itemsPerPage === index;
+    const shouldHighlight =
+      type === 'outputs' &&
+      foundIndex !== null &&
+      foundPage === page &&
+      foundIndex % itemsPerPage === index;
 
-      return (
-        <GenerateAccordion
-          items={items}
-          adjustedIndex={adjustedIndex}
-          expanded={expanded}
-          handleChange={handleChange}
-          expandedPanel={expandedPanel}
-          tabName={title}
-          key={adjustedIndex}
-          isHighlighted={shouldHighlight}
-        />
-      );
-    });
-  }
+    return (
+      <GenerateAccordion
+        items={items}
+        adjustedIndex={adjustedIndex}
+        expanded={expanded}
+        handleChange={handleChange}
+        expandedPanel={expandedPanel}
+        tabName={title}
+        key={adjustedIndex}
+        isHighlighted={shouldHighlight}
+      />
+    );
+  });
 
   const handlePageChange = (
     _event: React.ChangeEvent<unknown>,
@@ -308,23 +276,17 @@ function Outputs({ blockHeight, type, itemsPerPage }: OutputsProps) {
       )}
       {renderItems}
       <Stack justifyContent="center" mt={2} direction="row">
-        {totalItems > itemsPerPage &&
-          !(
-            type === 'outputs' &&
-            foundIndex !== null &&
-            foundIndex >= 0 &&
-            foundPage === page
-          ) && (
-            <Pagination
-              count={totalPages}
-              page={page}
-              onChange={handlePageChange}
-              showFirstButton
-              showLastButton
-              color="primary"
-              variant="outlined"
-            />
-          )}
+        {totalItems > itemsPerPage && (
+          <Pagination
+            count={totalPages}
+            page={page}
+            onChange={handlePageChange}
+            showFirstButton
+            showLastButton
+            color="primary"
+            variant="outlined"
+          />
+        )}
       </Stack>
     </>
   );

--- a/src/components/Header/StatsBox/StatsMobile/StatsMobile.styles.ts
+++ b/src/components/Header/StatsBox/StatsMobile/StatsMobile.styles.ts
@@ -30,7 +30,7 @@ export const StatsWrapperSml = styled(Box)(() => ({
   justifyContent: 'center',
   width: '100%',
   borderTop: '1px solid rgba(255, 255, 255, 0.1)',
-  padding: '12px 20px',
+  padding: '12px 6px',
   position: 'sticky',
   bottom: '0',
   left: '0',
@@ -45,6 +45,6 @@ export const StatsRowSml = styled(Box)(() => ({
   justifyContent: 'space-between',
   alignItems: 'center',
   width: '100%',
-  maxWidth: '500px',
-  gap: '24px',
+  maxWidth: '600px',
+  gap: '6px',
 }));

--- a/src/components/KernelSearch/BlockTable.tsx
+++ b/src/components/KernelSearch/BlockTable.tsx
@@ -108,7 +108,7 @@ function BlockTable({ data }: { data: any }) {
                   <TypographyData>{outputs}</TypographyData>
                 </Grid>
 
-                <Grid item xs={12}>
+                <Grid item xs={12} pb={2}>
                   <Link to={`/blocks/${height}`}>
                     <Button variant="outlined" fullWidth>
                       View Block

--- a/src/components/KernelSearch/KernelHeader.tsx
+++ b/src/components/KernelSearch/KernelHeader.tsx
@@ -61,36 +61,34 @@ function KernelHeader() {
 
   return (
     <>
-      {!isMobile ? (
-        <Container maxWidth="xl">
-          <Box
+      <Container maxWidth="xl">
+        <Box
+          style={{
+            marginTop: isMobile ? theme.spacing(5) : theme.spacing(10),
+            marginBottom: isMobile ? theme.spacing(5) : theme.spacing(10),
+            color: theme.palette.text.primary,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: isMobile ? 0 : theme.spacing(1),
+          }}
+        >
+          <Typography variant="body2" style={{ textTransform: 'uppercase' }}>
+            Kernel Search
+          </Typography>
+          <Typography
+            variant="h1"
             style={{
-              marginTop: theme.spacing(10),
-              marginBottom: theme.spacing(10),
-              color: theme.palette.text.primary,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: theme.spacing(1),
+              fontFamily: '"DrukHeavy", sans-serif',
+              fontSize: isMobile ? 40 : 60,
+              textTransform: 'uppercase',
             }}
           >
-            <Typography variant="body2" style={{ textTransform: 'uppercase' }}>
-              Kernel Search
-            </Typography>
-            <Typography
-              variant="h1"
-              style={{
-                fontFamily: '"DrukHeavy", sans-serif',
-                fontSize: 60,
-                textTransform: 'uppercase',
-              }}
-            >
-              {status}
-            </Typography>
-          </Box>
-        </Container>
-      ) : null}
+            {status}
+          </Typography>
+        </Box>
+      </Container>
     </>
   );
 }

--- a/src/components/PayRefSearch/BlockTable.tsx
+++ b/src/components/PayRefSearch/BlockTable.tsx
@@ -1,0 +1,252 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { useState, Fragment } from 'react';
+import { TypographyData } from '@components/StyledComponents';
+import { Typography, Grid, Divider, Pagination } from '@mui/material';
+import { toHexString, shortenString, formatTimestamp } from '@utils/helpers';
+import { Link } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CopyToClipboard from '@components/CopyToClipboard';
+import { useMainStore } from '@services/stores/useMainStore';
+import InnerHeading from '@components/InnerHeading';
+
+function BlockTable({ data }: { data: any }) {
+  const [page, setPage] = useState(1);
+  const isMobile = useMainStore((state) => state.isMobile);
+  const totalItems = data?.length || 0;
+  const itemsPerPage = 10;
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  console.log('BlockTable data:', data);
+
+  const handleChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+  };
+
+  function Mobile() {
+    const col1 = 4;
+    const col2 = 8;
+
+    return (
+      <Grid container spacing={2} pl={0} pr={0}>
+        {data.map((block: any, index: number) => {
+          const height = block?.block_height || 'no data';
+          const payref = block?.payment_reference_hex || 'no data';
+          const minedTimestamp = block?.mined_timestamp || 'no data';
+          const isSpent = block?.is_spent || false;
+          const minValuePromise = block?.min_value_promise || 'no data';
+          // const commitment = block?.commitment || 'no data';
+          const blockHash = toHexString(block?.block_hash?.data) || 'no data';
+          // const spentBlockHash =
+          //   toHexString(block?.spent_block_hash?.data) || 'no data';
+
+          return (
+            <Fragment key={index}>
+              <Grid item xs={12} key={index}>
+                <Divider />
+                <Grid container spacing={2} pl={0} pr={0} pb={2}>
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Height</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>
+                      <Link to={`/blocks/${height}`}>{height} </Link>
+                    </TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Payment Reference</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>
+                      {shortenString(payref, 6, 6)}
+                      <CopyToClipboard copy={payref} />
+                    </TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Mined Timestamp</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>
+                      {formatTimestamp(minedTimestamp)}
+                    </TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Spent</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>{isSpent ? 'Yes' : 'No'}</TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Min Value Promise</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>{minValuePromise}</TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Block Hash</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>
+                      {shortenString(blockHash, 6, 6)}
+                      <CopyToClipboard copy={blockHash} />
+                    </TypographyData>
+                  </Grid>
+                </Grid>
+                <Grid item xs={12}>
+                  <Link to={`/blocks/${height}`}>
+                    <Button variant="outlined" fullWidth>
+                      View Block
+                    </Button>
+                  </Link>
+                </Grid>
+              </Grid>
+            </Fragment>
+          );
+        })}
+      </Grid>
+    );
+  }
+
+  function Desktop() {
+    const col1 = 1;
+    const col2 = 2;
+    const col3 = 2;
+    const col4 = 1;
+    const col5 = 2;
+    const col6 = 2;
+
+    return (
+      <>
+        <Grid container spacing={2} pl={0} pr={0} pb={2} pt={2}>
+          <Grid item xs={col1} md={col1} lg={col1}>
+            <Typography variant="body2">Height</Typography>
+          </Grid>
+          <Grid item xs={col2} md={col2} lg={col2}>
+            <Typography variant="body2">Payment Reference</Typography>
+          </Grid>
+          <Grid item xs={col3} md={col3} lg={col3}>
+            <Typography variant="body2">Mined Timestamp</Typography>
+          </Grid>
+          <Grid item xs={col4} md={col4} lg={col4}>
+            <Typography variant="body2">Spent</Typography>
+          </Grid>
+          <Grid item xs={col5} md={col5} lg={col5}>
+            <Typography variant="body2">Min Value Promise</Typography>
+          </Grid>
+          <Grid item xs={col6} md={col6} lg={col6}>
+            <Typography variant="body2">Block Hash</Typography>
+          </Grid>
+        </Grid>
+        <Grid container spacing={2} pl={0} pr={0} pb={2}>
+          {data
+            ?.slice((page - 1) * itemsPerPage, page * itemsPerPage)
+            .map((block: any, index: number) => {
+              const height = block?.block_height || 'no data';
+              const payref = block?.payment_reference_hex || 'no data';
+              const minedTimestamp = block?.mined_timestamp || 'no data';
+              const isSpent = block?.is_spent || false;
+              const minValuePromise = block?.min_value_promise || 'no data';
+              // const commitment = block?.commitment || 'no data';
+              const blockHash =
+                toHexString(block?.block_hash?.data) || 'no data';
+              // const spentBlockHash =
+              //   toHexString(block?.spent_block_hash?.data) || 'no data';
+
+              return (
+                <Fragment key={index}>
+                  <Grid item xs={12}>
+                    <Divider />
+                  </Grid>
+                  <Grid item xs={col1} md={col1} lg={col1}>
+                    <TypographyData>
+                      <Link to={`/blocks/${height}`}>{height} </Link>
+                    </TypographyData>
+                  </Grid>
+                  <Grid item xs={col2} md={col2} lg={col2}>
+                    <TypographyData>
+                      {shortenString(payref, 6, 6)}
+                      <CopyToClipboard copy={payref} />
+                    </TypographyData>
+                  </Grid>
+                  <Grid item xs={col3} md={col3} lg={col3}>
+                    <TypographyData>
+                      {formatTimestamp(minedTimestamp)}
+                    </TypographyData>
+                  </Grid>
+                  <Grid item xs={col4} md={col4} lg={col4}>
+                    <TypographyData>{isSpent ? 'Yes' : 'No'}</TypographyData>
+                  </Grid>
+                  <Grid item xs={col5} md={col5} lg={col5}>
+                    <TypographyData>{minValuePromise}</TypographyData>
+                  </Grid>
+                  <Grid item xs={col6} md={col6} lg={col6}>
+                    <TypographyData>
+                      {shortenString(blockHash, 6, 6)}
+                      <CopyToClipboard copy={blockHash} />
+                    </TypographyData>
+                  </Grid>
+                </Fragment>
+              );
+            })}
+        </Grid>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <InnerHeading>Found in Block{totalItems > 1 && 's'}:</InnerHeading>
+      {isMobile ? <Mobile /> : <Desktop />}
+      <Divider />
+      {totalItems > itemsPerPage && (
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          pt={2}
+          pb={2}
+        >
+          <Pagination
+            count={totalPages}
+            color="primary"
+            page={page}
+            onChange={handleChange}
+            siblingCount={0}
+            boundaryCount={1}
+            showFirstButton
+            showLastButton
+            variant="outlined"
+          />
+        </Box>
+      )}
+    </>
+  );
+}
+
+export default BlockTable;

--- a/src/components/PayRefSearch/BlockTable.tsx
+++ b/src/components/PayRefSearch/BlockTable.tsx
@@ -23,7 +23,12 @@
 import { useState, Fragment } from 'react';
 import { TypographyData } from '@components/StyledComponents';
 import { Typography, Grid, Divider, Pagination } from '@mui/material';
-import { toHexString, shortenString, formatTimestamp } from '@utils/helpers';
+import {
+  toHexString,
+  shortenString,
+  formatTimestamp,
+  formatXTM,
+} from '@utils/helpers';
 import { Link } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -38,11 +43,17 @@ function BlockTable({ data }: { data: any }) {
   const itemsPerPage = 10;
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
-  console.log('BlockTable data:', data);
-
   const handleChange = (_event: React.ChangeEvent<unknown>, value: number) => {
     setPage(value);
   };
+
+  if (!data || data.length === 0) {
+    return (
+      <Typography variant="body2" color="textSecondary">
+        No blocks found.
+      </Typography>
+    );
+  }
 
   function Mobile() {
     const col1 = 4;
@@ -55,16 +66,15 @@ function BlockTable({ data }: { data: any }) {
           const payref = block?.payment_reference_hex || 'no data';
           const minedTimestamp = block?.mined_timestamp || 'no data';
           const isSpent = block?.is_spent || false;
-          const minValuePromise = block?.min_value_promise || 'no data';
-          // const commitment = block?.commitment || 'no data';
+          const minValuePromise =
+            formatXTM(block?.min_value_promise) || 'no data';
+          const commitment = toHexString(block?.commitment?.data) || 'no data';
           const blockHash = toHexString(block?.block_hash?.data) || 'no data';
-          // const spentBlockHash =
-          //   toHexString(block?.spent_block_hash?.data) || 'no data';
+          const spentBlockHash = toHexString(block?.spent_block_hash?.data);
 
           return (
             <Fragment key={index}>
               <Grid item xs={12} key={index}>
-                <Divider />
                 <Grid container spacing={2} pl={0} pr={0} pb={2}>
                   <Grid item xs={col1}>
                     <Typography variant="body2">Height</Typography>
@@ -109,6 +119,16 @@ function BlockTable({ data }: { data: any }) {
                   </Grid>
 
                   <Grid item xs={col1}>
+                    <Typography variant="body2">Commitment</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>
+                      {shortenString(commitment, 6, 6)}
+                      <CopyToClipboard copy={commitment} />
+                    </TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
                     <Typography variant="body2">Block Hash</Typography>
                   </Grid>
                   <Grid item xs={col2}>
@@ -117,13 +137,35 @@ function BlockTable({ data }: { data: any }) {
                       <CopyToClipboard copy={blockHash} />
                     </TypographyData>
                   </Grid>
+
+                  <Fragment>
+                    <Grid item xs={col1}>
+                      <Typography variant="body2">Spent Block Hash</Typography>
+                    </Grid>
+                    <Grid item xs={col2}>
+                      <TypographyData>
+                        {spentBlockHash?.length > 0 ? (
+                          <>
+                            {shortenString(spentBlockHash, 6, 6)}
+                            <CopyToClipboard copy={spentBlockHash} />
+                          </>
+                        ) : (
+                          'N/A'
+                        )}
+                      </TypographyData>
+                    </Grid>
+                  </Fragment>
                 </Grid>
-                <Grid item xs={12}>
+
+                <Grid item xs={12} pb={2}>
                   <Link to={`/blocks/${height}`}>
                     <Button variant="outlined" fullWidth>
                       View Block
                     </Button>
                   </Link>
+                </Grid>
+                <Grid item xs={12}>
+                  <Divider />
                 </Grid>
               </Grid>
             </Fragment>
@@ -137,9 +179,11 @@ function BlockTable({ data }: { data: any }) {
     const col1 = 1;
     const col2 = 2;
     const col3 = 2;
-    const col4 = 1;
-    const col5 = 2;
-    const col6 = 2;
+    const col4 = 0.75;
+    const col5 = 1.75;
+    const col6 = 1.75;
+    const col7 = 1.75;
+    const col8 = 1;
 
     return (
       <>
@@ -160,7 +204,13 @@ function BlockTable({ data }: { data: any }) {
             <Typography variant="body2">Min Value Promise</Typography>
           </Grid>
           <Grid item xs={col6} md={col6} lg={col6}>
+            <Typography variant="body2">Commitment</Typography>
+          </Grid>
+          <Grid item xs={col7} md={col7} lg={col7}>
             <Typography variant="body2">Block Hash</Typography>
+          </Grid>
+          <Grid item xs={col8} md={col8} lg={col8}>
+            <Typography variant="body2">Spent Block Hash</Typography>
           </Grid>
         </Grid>
         <Grid container spacing={2} pl={0} pr={0} pb={2}>
@@ -171,12 +221,13 @@ function BlockTable({ data }: { data: any }) {
               const payref = block?.payment_reference_hex || 'no data';
               const minedTimestamp = block?.mined_timestamp || 'no data';
               const isSpent = block?.is_spent || false;
-              const minValuePromise = block?.min_value_promise || 'no data';
-              // const commitment = block?.commitment || 'no data';
+              const minValuePromise =
+                formatXTM(block?.min_value_promise) || 'no data';
+              const commitment =
+                toHexString(block?.commitment?.data) || 'no data';
               const blockHash =
                 toHexString(block?.block_hash?.data) || 'no data';
-              // const spentBlockHash =
-              //   toHexString(block?.spent_block_hash?.data) || 'no data';
+              const spentBlockHash = toHexString(block?.spent_block_hash?.data);
 
               return (
                 <Fragment key={index}>
@@ -207,8 +258,26 @@ function BlockTable({ data }: { data: any }) {
                   </Grid>
                   <Grid item xs={col6} md={col6} lg={col6}>
                     <TypographyData>
+                      {shortenString(commitment, 6, 6)}
+                      <CopyToClipboard copy={commitment} />
+                    </TypographyData>
+                  </Grid>
+                  <Grid item xs={col7} md={col7} lg={col7}>
+                    <TypographyData>
                       {shortenString(blockHash, 6, 6)}
                       <CopyToClipboard copy={blockHash} />
+                    </TypographyData>
+                  </Grid>
+                  <Grid item xs={col8} md={col8} lg={col8}>
+                    <TypographyData>
+                      {spentBlockHash ? (
+                        <>
+                          {shortenString(spentBlockHash, 6, 6)}
+                          <CopyToClipboard copy={spentBlockHash} />
+                        </>
+                      ) : (
+                        'N/A'
+                      )}
                     </TypographyData>
                   </Grid>
                 </Fragment>

--- a/src/components/PayRefSearch/BlockTable.tsx
+++ b/src/components/PayRefSearch/BlockTable.tsx
@@ -55,6 +55,9 @@ function BlockTable({ data }: { data: any }) {
     );
   }
 
+  // const blockHeight = data.items[0].block_height;
+  // window.location.replace(`/blocks/${blockHeight}?payref=${payref}`);
+
   function Mobile() {
     const col1 = 4;
     const col2 = 8;
@@ -81,7 +84,9 @@ function BlockTable({ data }: { data: any }) {
                   </Grid>
                   <Grid item xs={col2}>
                     <TypographyData>
-                      <Link to={`/blocks/${height}`}>{height} </Link>
+                      <Link to={`/blocks/${height}?payref=${payref}`}>
+                        {height}{' '}
+                      </Link>
                     </TypographyData>
                   </Grid>
 
@@ -158,7 +163,7 @@ function BlockTable({ data }: { data: any }) {
                 </Grid>
 
                 <Grid item xs={12} pb={2}>
-                  <Link to={`/blocks/${height}`}>
+                  <Link to={`/blocks/${height}?payref=${payref}`}>
                     <Button variant="outlined" fullWidth>
                       View Block
                     </Button>
@@ -236,7 +241,9 @@ function BlockTable({ data }: { data: any }) {
                   </Grid>
                   <Grid item xs={col1} md={col1} lg={col1}>
                     <TypographyData>
-                      <Link to={`/blocks/${height}`}>{height} </Link>
+                      <Link to={`/blocks/${height}?payref=${payref}`}>
+                        {height}{' '}
+                      </Link>
                     </TypographyData>
                   </Grid>
                   <Grid item xs={col2} md={col2} lg={col2}>

--- a/src/components/PayRefSearch/BlockTable.tsx
+++ b/src/components/PayRefSearch/BlockTable.tsx
@@ -22,7 +22,7 @@
 
 import { useState, Fragment } from 'react';
 import { TypographyData } from '@components/StyledComponents';
-import { Typography, Grid, Divider, Pagination } from '@mui/material';
+import { Typography, Grid, Divider, Pagination, Alert } from '@mui/material';
 import {
   toHexString,
   shortenString,
@@ -49,9 +49,9 @@ function BlockTable({ data }: { data: any }) {
 
   if (!data || data.length === 0) {
     return (
-      <Typography variant="body2" color="textSecondary">
+      <Alert severity="error" variant="outlined">
         No blocks found.
-      </Typography>
+      </Alert>
     );
   }
 

--- a/src/components/PayRefSearch/PayRefHeader.tsx
+++ b/src/components/PayRefSearch/PayRefHeader.tsx
@@ -42,8 +42,8 @@ function PayRefHeader() {
     case isFetching:
       status = 'Searching...';
       break;
-    case isError:
-      status = 'Block not found';
+    case isError || data?.items.length === 0:
+      status = 'Not found';
       break;
     case isSuccess:
       status = `Block${data.items.length > 1 ? 's' : ''} found`;
@@ -52,38 +52,41 @@ function PayRefHeader() {
       status = '';
   }
 
+  // if (data?.items.length === 1) {
+  //   const blockHeight = data.items[0].block_height;
+  //   window.location.replace(`/blocks/${blockHeight}?payref=${payref}`);
+  // }
+
   return (
     <>
-      {!isMobile ? (
-        <Container maxWidth="xl">
-          <Box
+      <Container maxWidth="xl">
+        <Box
+          style={{
+            marginTop: isMobile ? theme.spacing(5) : theme.spacing(10),
+            marginBottom: isMobile ? theme.spacing(5) : theme.spacing(10),
+            color: theme.palette.text.primary,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: isMobile ? 0 : theme.spacing(1),
+          }}
+        >
+          <Typography variant="body2" style={{ textTransform: 'uppercase' }}>
+            PayRef Search
+          </Typography>
+          <Typography
+            variant="h1"
             style={{
-              marginTop: theme.spacing(10),
-              marginBottom: theme.spacing(10),
-              color: theme.palette.text.primary,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: theme.spacing(1),
+              fontFamily: '"DrukHeavy", sans-serif',
+              fontSize: isMobile ? 40 : 60,
+              textTransform: 'uppercase',
             }}
           >
-            <Typography variant="body2" style={{ textTransform: 'uppercase' }}>
-              PayRef Search
-            </Typography>
-            <Typography
-              variant="h1"
-              style={{
-                fontFamily: '"DrukHeavy", sans-serif',
-                fontSize: 60,
-                textTransform: 'uppercase',
-              }}
-            >
-              {status}
-            </Typography>
-          </Box>
-        </Container>
-      ) : null}
+            {status}
+          </Typography>
+        </Box>
+      </Container>
     </>
   );
 }

--- a/src/components/PayRefSearch/PayRefHeader.tsx
+++ b/src/components/PayRefSearch/PayRefHeader.tsx
@@ -52,10 +52,10 @@ function PayRefHeader() {
       status = '';
   }
 
-  // if (data?.items.length === 1) {
-  //   const blockHeight = data.items[0].block_height;
-  //   window.location.replace(`/blocks/${blockHeight}?payref=${payref}`);
-  // }
+  if (data?.items.length === 1) {
+    const blockHeight = data.items[0].block_height;
+    window.location.replace(`/blocks/${blockHeight}?payref=${payref}`);
+  }
 
   return (
     <>

--- a/src/components/PayRefSearch/PayRefHeader.tsx
+++ b/src/components/PayRefSearch/PayRefHeader.tsx
@@ -1,0 +1,91 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { Box, Container, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { useLocation } from 'react-router-dom';
+import { useSearchByPayref } from '@services/api/hooks/useBlocks';
+import { useMediaQuery } from '@mui/material';
+
+function PayRefHeader() {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+
+  const payref = params.get('payref') || '';
+
+  const { isFetching, isError, isSuccess, data } = useSearchByPayref(payref);
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  let status = '';
+  switch (true) {
+    case isFetching:
+      status = 'Searching...';
+      break;
+    case isError:
+      status = 'Block not found';
+      break;
+    case isSuccess:
+      status = `Block${data.items.length > 1 ? 's' : ''} found`;
+      break;
+    default:
+      status = '';
+  }
+
+  return (
+    <>
+      {!isMobile ? (
+        <Container maxWidth="xl">
+          <Box
+            style={{
+              marginTop: theme.spacing(10),
+              marginBottom: theme.spacing(10),
+              color: theme.palette.text.primary,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: theme.spacing(1),
+            }}
+          >
+            <Typography variant="body2" style={{ textTransform: 'uppercase' }}>
+              PayRef Search
+            </Typography>
+            <Typography
+              variant="h1"
+              style={{
+                fontFamily: '"DrukHeavy", sans-serif',
+                fontSize: 60,
+                textTransform: 'uppercase',
+              }}
+            >
+              {status}
+            </Typography>
+          </Box>
+        </Container>
+      ) : null}
+    </>
+  );
+}
+
+export default PayRefHeader;

--- a/src/components/Search/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react';
 import { IoSearch } from 'react-icons/io5';
 import SearchBlock from './SearchBlock';
 import SearchKernel from './SearchKernel';
+import SearchPayRef from './SearchPayRef';
 import { StyledFormControlLabel } from './AdvancedSearch.styles';
 import { useMainStore } from '@services/stores/useMainStore';
 import { ThemeProvider } from '@emotion/react';
@@ -18,10 +19,12 @@ import { lightTheme } from '@theme/themes';
 import InnerHeading from '@components/InnerHeading';
 import { IoClose } from 'react-icons/io5';
 
+type SearchType = 'payref' | 'block' | 'kernel';
+
 export default function AdvancedSearch() {
   const searchOpen = useMainStore((state) => state.searchOpen);
   const setSearchOpen = useMainStore((state) => state.setSearchOpen);
-  const [searchType, setSearchType] = useState<'block' | 'kernel'>('block');
+  const [searchType, setSearchType] = useState<SearchType>('payref');
 
   const handleClickOpen = () => {
     setSearchOpen(true);
@@ -34,7 +37,7 @@ export default function AdvancedSearch() {
   const handleSearchTypeChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setSearchType(event.target.value as 'block' | 'kernel');
+    setSearchType(event.target.value as SearchType);
   };
 
   return (
@@ -67,6 +70,11 @@ export default function AdvancedSearch() {
                 name="search-type"
               >
                 <StyledFormControlLabel
+                  value="payref"
+                  control={<Radio />}
+                  label="Payment Reference"
+                />
+                <StyledFormControlLabel
                   value="block"
                   control={<Radio />}
                   label="Block"
@@ -78,7 +86,16 @@ export default function AdvancedSearch() {
                 />
               </RadioGroup>
             </FormControl>
-            {searchType === 'block' ? <SearchBlock /> : <SearchKernel />}
+            {(() => {
+              switch (searchType) {
+                case 'payref':
+                  return <SearchPayRef />;
+                case 'block':
+                  return <SearchBlock />;
+                default:
+                  return <SearchKernel />;
+              }
+            })()}
           </DialogContent>
         </Dialog>
       </ThemeProvider>

--- a/src/components/Search/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch.tsx
@@ -10,7 +10,6 @@ import {
 import { useState } from 'react';
 import { IoSearch } from 'react-icons/io5';
 import SearchBlock from './SearchBlock';
-import SearchKernel from './SearchKernel';
 import SearchPayRef from './SearchPayRef';
 import { StyledFormControlLabel } from './AdvancedSearch.styles';
 import { useMainStore } from '@services/stores/useMainStore';
@@ -79,23 +78,9 @@ export default function AdvancedSearch() {
                   control={<Radio />}
                   label="Block"
                 />
-                <StyledFormControlLabel
-                  value="kernel"
-                  control={<Radio />}
-                  label="Kernel"
-                />
               </RadioGroup>
             </FormControl>
-            {(() => {
-              switch (searchType) {
-                case 'payref':
-                  return <SearchPayRef />;
-                case 'block':
-                  return <SearchBlock />;
-                default:
-                  return <SearchKernel />;
-              }
-            })()}
+            {searchType === 'payref' ? <SearchPayRef /> : <SearchBlock />}
           </DialogContent>
         </Dialog>
       </ThemeProvider>

--- a/src/components/Search/AdvancedSearch.tsx
+++ b/src/components/Search/AdvancedSearch.tsx
@@ -72,7 +72,7 @@ export default function AdvancedSearch() {
                 <StyledFormControlLabel
                   value="payref"
                   control={<Radio />}
-                  label="Payment Reference"
+                  label="Payment Reference (PayRef)"
                 />
                 <StyledFormControlLabel
                   value="block"

--- a/src/components/Search/SearchKernel.tsx
+++ b/src/components/Search/SearchKernel.tsx
@@ -59,7 +59,7 @@ const SearchKernel = () => {
     <Stack gap={2} pb={2}>
       <TextField
         label="Nonce"
-        placeholder="Enter Nonce"
+        placeholder="Enter 64-character nonce hash"
         name="nonce"
         variant="outlined"
         size="small"
@@ -81,7 +81,7 @@ const SearchKernel = () => {
       />
       <TextField
         label="Signature"
-        placeholder="Enter Signature"
+        placeholder="Enter 64-character signature hash"
         name="signature"
         variant="outlined"
         size="small"
@@ -110,10 +110,6 @@ const SearchKernel = () => {
         </Button>
       </Stack>
       {message && (
-        // <Typography variant="body2" color="textSecondary">
-        //   {message}
-        // </Typography>
-
         <Alert severity="error" variant="standard">
           {message}
         </Alert>

--- a/src/components/Search/SearchPayRef.styles.ts
+++ b/src/components/Search/SearchPayRef.styles.ts
@@ -1,0 +1,26 @@
+import { styled } from '@mui/material/styles';
+import { TextField, IconButton } from '@mui/material';
+
+export const StyledTextField = styled(TextField)(({ theme }) => ({
+  width: '400px',
+  [theme.breakpoints.down('md')]: {
+    width: '100%',
+  },
+}));
+
+export const SearchIconButton = styled(IconButton)({
+  padding: 0,
+  borderRadius: 40,
+  background: 'none',
+});
+
+export const CloseIconButton = styled(IconButton)({
+  padding: 0,
+  borderRadius: 40,
+  background: 'none',
+});
+
+export const ExpandIconButton = styled(IconButton)({
+  borderRadius: 40,
+  padding: 0,
+});

--- a/src/components/Search/SearchPayRef.tsx
+++ b/src/components/Search/SearchPayRef.tsx
@@ -54,7 +54,7 @@ const PayRef = () => {
     <Stack gap={1} pb={2}>
       <TextField
         label="Search by payment reference"
-        placeholder="Enter 64-character hash"
+        placeholder="Enter 64-character PayRef hash"
         autoFocus
         value={query}
         onChange={handleInputChange}

--- a/src/components/Search/SearchPayRef.tsx
+++ b/src/components/Search/SearchPayRef.tsx
@@ -3,6 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { Button, Stack, TextField, Alert } from '@mui/material';
 import { useMainStore } from '@services/stores/useMainStore';
 
+export const validatePayRefQuery = (query: string) => {
+  const isHash = query.length === 64;
+  return isHash;
+};
+
 const PayRef = () => {
   const searchOpen = useMainStore((state) => state.searchOpen);
   const setSearchOpen = useMainStore((state) => state.setSearchOpen);
@@ -17,16 +22,11 @@ const PayRef = () => {
     }
   }, [searchOpen]);
 
-  const validateQuery = (query: string) => {
-    const isHash = query.length === 64;
-    return isHash;
-  };
-
   const handleSearch = () => {
     if (query === '') {
       return;
     }
-    if (!validateQuery(query)) {
+    if (!validatePayRefQuery(query)) {
       setMessage('Please enter a valid payment reference');
       setQuery('');
       return;

--- a/src/components/Search/SearchPayRef.tsx
+++ b/src/components/Search/SearchPayRef.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button, Stack, TextField, Alert } from '@mui/material';
+import { useMainStore } from '@services/stores/useMainStore';
+
+const PayRef = () => {
+  const searchOpen = useMainStore((state) => state.searchOpen);
+  const setSearchOpen = useMainStore((state) => state.setSearchOpen);
+  const [message, setMessage] = useState('');
+  const [query, setQuery] = useState('');
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (searchOpen && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [searchOpen]);
+
+  const validateQuery = (query: string) => {
+    const isHash = query.length === 64;
+    return isHash;
+  };
+
+  const handleSearch = () => {
+    if (query === '') {
+      return;
+    }
+    if (!validateQuery(query)) {
+      setMessage('Please enter a valid payment reference');
+      setQuery('');
+      return;
+    }
+    navigate(`/search_outputs_by_payref?payref=${query}`);
+    setSearchOpen(false);
+    setQuery('');
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.target.value);
+  };
+
+  const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  const handleCancel = () => {
+    setSearchOpen(false);
+  };
+
+  return (
+    <Stack gap={1} pb={2}>
+      <TextField
+        label="Search by payment reference"
+        placeholder="Enter 64-character hash"
+        autoFocus
+        value={query}
+        onChange={handleInputChange}
+        size="small"
+        onKeyPress={handleKeyPress}
+        fullWidth
+        InputLabelProps={{ shrink: true }}
+        inputRef={inputRef}
+      />
+      <Stack direction="row" gap={1} justifyContent="flex-end">
+        <Button onClick={handleCancel}>Cancel</Button>
+        <Button onClick={handleSearch} variant="contained">
+          Search
+        </Button>
+      </Stack>
+      {message && (
+        <Alert severity="error" variant="standard">
+          {message}
+        </Alert>
+      )}
+    </Stack>
+  );
+};
+
+export default PayRef;

--- a/src/components/StyledComponents.ts
+++ b/src/components/StyledComponents.ts
@@ -29,10 +29,12 @@ import Typography from '@mui/material/Typography';
 import Accordion from '@mui/material/Accordion';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
+import AccordionSummary from '@mui/material/AccordionSummary';
 
 interface StyledAccordionProps {
   theme?: any;
   isHighlighted?: boolean;
+  expanded?: boolean;
 }
 
 export const AccordionIconButton = styled(IconButton)(({ theme }) => ({
@@ -62,6 +64,15 @@ export const StyledAccordion = styled(Accordion, {
   '&:before': {
     display: 'none',
   },
+}));
+
+export const StyledAccordionSummary = styled(AccordionSummary, {
+  shouldForwardProp: (prop) => prop !== 'isHighlighted',
+})<StyledAccordionProps>(({ theme, isHighlighted, expanded }) => ({
+  backgroundColor: isHighlighted ? '#1D1928' : 'transparent',
+  color: isHighlighted ? '#fff' : 'inherit',
+  borderRadius: expanded ? `16px 16px 0 0` : theme.shape.borderRadius,
+  transition: 'background-color 0.3s ease',
 }));
 
 export const TypographyData = styled(Typography)(({ theme }) => ({
@@ -99,15 +110,6 @@ export const PageHeading = styled(Typography)(({ theme }) => ({
   letterSpacing: '1.5px',
   color: theme.palette.text.primary,
 }));
-
-// export const InnerHeading = styled(Typography)(({ theme }) => ({
-//   fontSize: theme.typography.h3.fontSize,
-//   fontFamily: "'DrukHeavy', sans-serif",
-//   textTransform: 'uppercase',
-//   borderBottom: `1px solid ${theme.palette.divider}`,
-//   paddingBottom: theme.spacing(1),
-//   marginBottom: theme.spacing(2),
-// }));
 
 export const DataTableCell = styled(TableCell)(() => ({
   fontFamily: "'PoppinsRegular', sans-serif",

--- a/src/components/StyledComponents.ts
+++ b/src/components/StyledComponents.ts
@@ -48,11 +48,13 @@ export const StyledAccordion = styled(Accordion, {
   shouldForwardProp: (prop) => prop !== 'isHighlighted',
 })<StyledAccordionProps>(({ theme, isHighlighted }) => ({
   backgroundColor: theme.palette.background.paper,
-  boxShadow: '1px 5px 28px rgba(35, 11, 73, 0.05)',
+  boxShadow: isHighlighted
+    ? '0px 5px 20px rgba(35, 11, 73, 0.15)'
+    : '0px 2px 4px rgba(35, 11, 73, 0.05)',
   borderRadius: theme.shape.borderRadius,
   marginBottom: theme.spacing(1),
   border: isHighlighted
-    ? `2px solid ${theme.palette.secondary.main}`
+    ? `2px solid rgba(255, 255, 255, 0.08)`
     : '2px solid rgba(255,255,255,0.04)',
   '&:hover': {
     backgroundColor: '#fafafc',

--- a/src/components/StyledComponents.ts
+++ b/src/components/StyledComponents.ts
@@ -48,12 +48,12 @@ export const StyledAccordion = styled(Accordion, {
   shouldForwardProp: (prop) => prop !== 'isHighlighted',
 })<StyledAccordionProps>(({ theme, isHighlighted }) => ({
   backgroundColor: theme.palette.background.paper,
-  boxShadow: isHighlighted
-    ? '1px 5px 28px rgba(35, 11, 73, 0.25)'
-    : '1px 5px 28px rgba(35, 11, 73, 0.05)',
+  boxShadow: '1px 5px 28px rgba(35, 11, 73, 0.05)',
   borderRadius: theme.shape.borderRadius,
   marginBottom: theme.spacing(1),
-  border: isHighlighted ? '1px solid #e1e1e1' : '1px solid #f8f8f8',
+  border: isHighlighted
+    ? `2px solid ${theme.palette.secondary.main}`
+    : '2px solid rgba(255,255,255,0.04)',
   '&:hover': {
     backgroundColor: '#fafafc',
   },

--- a/src/routes/BlockPage.tsx
+++ b/src/routes/BlockPage.tsx
@@ -28,7 +28,8 @@ import { useLocation } from 'react-router-dom';
 import { useGetBlockByHeightOrHash } from '@services/api/hooks/useBlocks';
 import FetchStatusCheck from '@components/FetchStatusCheck';
 import BlockParts from '@components/Blocks/BlockParts';
-import BlockPartsSearch from '@components/Blocks/BlockPartsSearch';
+import Kernels from '@components/Blocks/Kernels';
+import Outputs from '@components/Blocks/Outputs';
 import BlockRewards from '@components/Blocks/BlockRewards';
 
 function BlockPage() {
@@ -88,14 +89,14 @@ function BlockPage() {
           }}
         >
           <GradientPaper>
-            <BlockPartsSearch
+            <Kernels
               blockHeight={blockHeight}
               type="kernels"
               itemsPerPage={5}
             />
           </GradientPaper>
           <GradientPaper>
-            <BlockParts
+            <Outputs
               blockHeight={blockHeight}
               type="outputs"
               itemsPerPage={5}

--- a/src/routes/PayRefSearchPage.tsx
+++ b/src/routes/PayRefSearchPage.tsx
@@ -1,0 +1,68 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { GradientPaper } from '@components/StyledComponents';
+import { Grid } from '@mui/material';
+import { useLocation } from 'react-router-dom';
+import { useSearchByPayref } from '@services/api/hooks/useBlocks';
+import FetchStatusCheck from '@components/FetchStatusCheck';
+import BlockTable from '@components/PayRefSearch/BlockTable';
+
+function PayRefSearchPage() {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+
+  const payref = params.get('payref') || '';
+
+  const { data, isLoading, isError, error } = useSearchByPayref(payref);
+
+  if (isLoading || isError) {
+    return (
+      <Grid item xs={12} md={12} lg={12}>
+        <GradientPaper>
+          <FetchStatusCheck
+            isError={isError}
+            isLoading={isLoading}
+            errorMessage={error?.message || 'Error retrieving data'}
+          />
+        </GradientPaper>
+      </Grid>
+    );
+  }
+
+  // if (data?.items.length === 1) {
+  //   const blockHeight = data.items[0].block.header.height;
+  //   window.location.replace(
+  //     `/blocks/${blockHeight}?nonce=${noncesParams}&signature=${signaturesParams}`
+  //   );
+  // }
+
+  return (
+    <Grid item xs={12} md={12} lg={12}>
+      <GradientPaper>
+        <BlockTable data={data?.items || []} />
+      </GradientPaper>
+    </Grid>
+  );
+}
+
+export default PayRefSearchPage;

--- a/src/services/api/hooks/useBlocks.tsx
+++ b/src/services/api/hooks/useBlocks.tsx
@@ -109,8 +109,6 @@ export const useSearchByKernel = (nonces: string[], signatures: string[]) => {
   });
 };
 
-// 7c471c219239df235e80b1a00f88b48a4a52e687eb96c52cc31f7787e5d91f11
-
 export const useSearchByPayref = (payref: string) => {
   return useQuery({
     queryKey: ['payref', payref],

--- a/src/services/api/hooks/useBlocks.tsx
+++ b/src/services/api/hooks/useBlocks.tsx
@@ -108,3 +108,21 @@ export const useSearchByKernel = (nonces: string[], signatures: string[]) => {
     },
   });
 };
+
+// 7c471c219239df235e80b1a00f88b48a4a52e687eb96c52cc31f7787e5d91f11
+
+export const useSearchByPayref = (payref: string) => {
+  return useQuery({
+    queryKey: ['payref', payref],
+    queryFn: () =>
+      jsonRpc(
+        `${address}/search_outputs_by_payref?payref=${payref}&json`,
+        'PayRef not found'
+      ).then((resp) => {
+        return resp;
+      }),
+    onError: (error: apiError) => {
+      return error;
+    },
+  });
+};

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -33,7 +33,7 @@ import {
 
 export const componentSettings: ThemeOptions = {
   shape: {
-    borderRadius: 8,
+    borderRadius: 16,
   },
   spacing: 8,
   typography: {
@@ -151,7 +151,7 @@ export const componentSettings: ThemeOptions = {
       defaultProps: {
         PaperProps: {
           sx: {
-            borderRadius: 4,
+            borderRadius: 2,
             boxShadow: '0px 4px 25px rgba(0, 0, 0, 0.1)',
           },
         },

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -140,6 +140,10 @@ function formatHash(number: number, decimals: number = 1) {
   return number.toFixed(decimals) + ' ' + suffixes[suffixIndex] + 'H';
 }
 
+function formatXTM(amount: number): string {
+  return amount / 1_000_000 + ' XTM';
+}
+
 function powCheck(num: string): string {
   let powText = '';
   switch (num) {
@@ -170,5 +174,6 @@ export {
   handleChangeRowsPerPage,
   formatTimestamp,
   formatHash,
+  formatXTM,
   powCheck,
 };

--- a/src/utils/searchFunctions.ts
+++ b/src/utils/searchFunctions.ts
@@ -33,4 +33,19 @@ const kernelSearch = (
   return foundIndex !== -1 ? foundIndex : null;
 };
 
-export { kernelSearch };
+const payrefSearch = (payref: string, outputs: any[]): number | null => {
+  if (!outputs) return null;
+
+  const foundIndex = outputs.findIndex((output) => {
+    const payment_reference = toHexString(output.payment_reference.data);
+    const payrefMatch = payref ? payment_reference.includes(payref) : false;
+    if (payref) {
+      return payrefMatch;
+    }
+    return false;
+  });
+
+  return foundIndex !== -1 ? foundIndex : null;
+};
+
+export { kernelSearch, payrefSearch };

--- a/src/utils/searchFunctions.ts
+++ b/src/utils/searchFunctions.ts
@@ -38,7 +38,7 @@ const payrefSearch = (payref: string, outputs: any[]): number | null => {
 
   const foundIndex = outputs.findIndex((output) => {
     const payment_reference = toHexString(output.payment_reference.data);
-    const payrefMatch = payref ? payment_reference.includes(payref) : false;
+    const payrefMatch = payref ? payment_reference === payref : false;
     if (payref) {
       return payrefMatch;
     }


### PR DESCRIPTION
Description
---
Adds the ability to search for an output using PayRef

Motivation and Context
---
Gives users the ability to confirm that their transaction has been mined

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Click on the search icon and paste in a valid PayRef
The search can also be triggered by adding the PayRef in the url like this:

Single payref:
`https://payref.tari-block-explore-mainnet.pages.dev/search_outputs_by_payref?payref=cfd6e7c67f4fe23e4e2cff68400ecd837ea57ca01287bed500ddcce9eb559f9b`

Multiple payrefs (comma separated):
`https://payref.tari-block-explore-mainnet.pages.dev/search_outputs_by_payref?payref=cfd6e7c67f4fe23e4e2cff68400ecd837ea57ca01287bed500ddcce9eb559f9b,47c082b1c487ac76be687b0862efbaeae18107506680ac493ac515d2f9800009`

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
