### PR TITLE
feat: combine search functions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,8 @@ import { useMediaQuery, useTheme } from '@mui/material';
 import { useMainStore } from '@services/stores/useMainStore';
 import { useEffect } from 'react';
 import PayRefSearchPage from '@routes/PayRefSearchPage';
+import SearchPage from '@routes/SearchPage';
+import SearchPageHeader from '@components/Search/SearchPageHeader';
 import PayRefHeader from '@components/PayRefSearch/PayRefHeader';
 
 function App() {
@@ -76,6 +78,12 @@ function App() {
           element={<PageLayout customHeader={<PayRefHeader />} />}
         >
           <Route index element={<PayRefSearchPage />} />
+        </Route>
+        <Route
+          path="search"
+          element={<PageLayout customHeader={<SearchPageHeader />} />}
+        >
+          <Route index element={<SearchPage />} />
         </Route>
         <Route path="mempool" element={<PageLayout title="Mempool" />}>
           <Route index element={<MempoolPage />} />

--- a/src/components/Header/HeaderBottom/HeaderBottom.styles.ts
+++ b/src/components/Header/HeaderBottom/HeaderBottom.styles.ts
@@ -7,4 +7,5 @@ export const StyledContainer = styled(Box)(({ theme }) => ({
   justifyContent: 'space-between',
   color: theme.palette.text.primary,
   width: '100%',
+  minHeight: '50px',
 }));

--- a/src/components/Header/HeaderBottom/HeaderBottom.tsx
+++ b/src/components/Header/HeaderBottom/HeaderBottom.tsx
@@ -23,17 +23,19 @@
 import { StyledContainer } from './HeaderBottom.styles';
 import StatsBox from '../StatsBox/StatsBox';
 import { useMainStore } from '@services/stores/useMainStore';
-import AdvancedSearch from '@components/Search/AdvancedSearch';
+import SearchField from '../SearchField/SearchField';
+import { useState } from 'react';
 
 export default function HeaderBottom() {
   const isMobile = useMainStore((state) => state.isMobile);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   return (
     <StyledContainer>
       {!isMobile && (
         <>
           <StatsBox variant="desktop" />
-          <AdvancedSearch />
+          <SearchField isExpanded={isExpanded} setIsExpanded={setIsExpanded} />
         </>
       )}
     </StyledContainer>

--- a/src/components/Header/HeaderBottom/HeaderBottom.tsx
+++ b/src/components/Header/HeaderBottom/HeaderBottom.tsx
@@ -25,17 +25,25 @@ import StatsBox from '../StatsBox/StatsBox';
 import { useMainStore } from '@services/stores/useMainStore';
 import SearchField from '../SearchField/SearchField';
 import { useState } from 'react';
+import { useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 
 export default function HeaderBottom() {
   const isMobile = useMainStore((state) => state.isMobile);
-  const [isExpanded, setIsExpanded] = useState(false);
+  const theme = useTheme();
+  const isLg = useMediaQuery(theme.breakpoints.down('lg'));
+  const [isExpanded, setIsExpanded] = useState(true);
 
   return (
     <StyledContainer>
       {!isMobile && (
         <>
-          <StatsBox variant="desktop" />
-          <SearchField isExpanded={isExpanded} setIsExpanded={setIsExpanded} />
+          {(!isLg || isExpanded === false) && <StatsBox variant="desktop" />}
+          <SearchField
+            isExpanded={isExpanded}
+            setIsExpanded={setIsExpanded}
+            fullWidth={isLg ? true : false}
+          />
         </>
       )}
     </StyledContainer>

--- a/src/components/Header/HeaderBottom/HeaderBottom.tsx
+++ b/src/components/Header/HeaderBottom/HeaderBottom.tsx
@@ -32,7 +32,7 @@ export default function HeaderBottom() {
   const isMobile = useMainStore((state) => state.isMobile);
   const theme = useTheme();
   const isLg = useMediaQuery(theme.breakpoints.down('lg'));
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   return (
     <StyledContainer>

--- a/src/components/Header/MobileHeader/MobileHeader.tsx
+++ b/src/components/Header/MobileHeader/MobileHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
   HeaderTop,
   Inside,
@@ -16,12 +16,12 @@ import { SocialIconButtons } from '@components/SocialLinks/SocialLinks';
 import MobileNavigation from './MobileNavigation/MobileNavigation';
 import Gem from '@assets/images/tari-gem.svg';
 import { Link } from 'react-router-dom';
-import AdvancedSearch from '@components/Search/AdvancedSearch';
+import SearchField from '@components/Header/SearchField/SearchField';
 
 export default function MobileHeader() {
   const showMobileMenu = useMainStore((state) => state.showMobileMenu);
   const setShowMobileMenu = useMainStore((state) => state.setShowMobileMenu);
-  const isExpanded = false;
+  const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
     if (showMobileMenu) {
@@ -64,7 +64,10 @@ export default function MobileHeader() {
                 </>
               )}
               <IconsContainer $isExpanded={isExpanded}>
-                <AdvancedSearch />
+                <SearchField
+                  isExpanded={isExpanded}
+                  setIsExpanded={setIsExpanded}
+                />
                 <MobileMenuButton />
               </IconsContainer>
             </Inner>

--- a/src/components/Header/SearchField/SearchField.styles.ts
+++ b/src/components/Header/SearchField/SearchField.styles.ts
@@ -1,12 +1,5 @@
 import { styled } from '@mui/material/styles';
-import { TextField, IconButton } from '@mui/material';
-
-export const StyledTextField = styled(TextField)(({ theme }) => ({
-  width: '400px',
-  [theme.breakpoints.down('md')]: {
-    width: '100%',
-  },
-}));
+import { IconButton } from '@mui/material';
 
 export const SearchIconButton = styled(IconButton)({
   padding: 0,

--- a/src/components/Header/SearchField/SearchField.tsx
+++ b/src/components/Header/SearchField/SearchField.tsx
@@ -21,31 +21,32 @@ const SearchField = ({
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
 
-  const validateQuery = (query: string) => {
-    const height = parseInt(query);
-    const isHeight = !isNaN(height) && height >= 0;
-    const isHash = query.length === 64;
-    return isHeight || isHash;
-  };
-
   const handleSearch = () => {
     if (query === '') {
       setIsExpanded(false);
       return;
     }
-    if (!validateQuery(query)) {
+    const isHeight = /^\d+$/.test(query);
+    const isHash = /^[a-fA-F0-9]{64}$/.test(query);
+
+    if (!isHeight && !isHash) {
       setOpen(true);
       setQuery('');
       setIsExpanded(false);
       return;
     }
-    navigate(`/blocks/${query}`);
+
+    if (isHeight) {
+      navigate(`/blocks/${query}`);
+    } else if (isHash) {
+      navigate(`/search?hash=${query}`);
+    }
     setQuery('');
     setIsExpanded(false);
   };
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setQuery(event.target.value);
+    setQuery(event.target.value.toLowerCase().trim());
   };
 
   const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -61,7 +62,8 @@ const SearchField = ({
       {isExpanded && (
         <Fade in={isExpanded} timeout={500}>
           <StyledTextField
-            label="Search by height or hash"
+            label="Search"
+            placeholder="Search by PayRef / Block Height / Block Hash"
             autoFocus
             value={query}
             onChange={handleInputChange}

--- a/src/components/Header/SearchField/SearchField.tsx
+++ b/src/components/Header/SearchField/SearchField.tsx
@@ -9,6 +9,7 @@ import {
   ExpandIconButton,
 } from './SearchField.styles';
 import { useMainStore } from '@services/stores/useMainStore';
+import { validateHash, validateHeight } from '@utils/helpers';
 
 const SearchField = ({
   isExpanded,
@@ -29,8 +30,8 @@ const SearchField = ({
       setIsExpanded(false);
       return;
     }
-    const isHeight = /^\d+$/.test(query);
-    const isHash = /^[a-fA-F0-9]{64}$/.test(query);
+    const isHeight = validateHeight(query);
+    const isHash = validateHash(query);
 
     if (!isHeight && !isHash) {
       setOpen(true);

--- a/src/components/Header/SearchField/SearchField.tsx
+++ b/src/components/Header/SearchField/SearchField.tsx
@@ -1,25 +1,28 @@
 import React, { useState } from 'react';
-import { Fade, InputAdornment } from '@mui/material';
+import { Fade, InputAdornment, TextField } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { IoSearch, IoClose } from 'react-icons/io5';
 import SnackbarAlert from '../../SnackbarAlert';
 import {
-  StyledTextField,
   SearchIconButton,
   CloseIconButton,
   ExpandIconButton,
 } from './SearchField.styles';
+import { useMainStore } from '@services/stores/useMainStore';
 
 const SearchField = ({
   isExpanded,
   setIsExpanded,
+  fullWidth = false,
 }: {
   isExpanded: boolean;
   setIsExpanded: (expanded: boolean) => void;
+  fullWidth?: boolean;
 }) => {
   const [query, setQuery] = useState('');
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
+  const isMobile = useMainStore((state) => state.isMobile);
 
   const handleSearch = () => {
     if (query === '') {
@@ -61,13 +64,14 @@ const SearchField = ({
       <SnackbarAlert open={open} setOpen={setOpen} message="Invalid query" />
       {isExpanded && (
         <Fade in={isExpanded} timeout={500}>
-          <StyledTextField
-            label="Search"
-            placeholder="Search by PayRef / Block Height / Block Hash"
+          <TextField
+            label="Search by PayRef / Block Height / Block Hash"
+            placeholder="Enter 64 character hash or block height"
             autoFocus
             value={query}
             onChange={handleInputChange}
             size="small"
+            style={{ width: fullWidth || isMobile ? '100%' : '440px' }}
             onKeyPress={handleKeyPress}
             InputProps={
               query !== ''

--- a/src/components/Search/BlockTable.tsx
+++ b/src/components/Search/BlockTable.tsx
@@ -1,0 +1,163 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { useState } from 'react';
+import { TypographyData } from '@components/StyledComponents';
+import { Typography, Grid, Divider, Pagination, Alert } from '@mui/material';
+import { toHexString, shortenString, formatTimestamp } from '@utils/helpers';
+import { Link } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CopyToClipboard from '@components/CopyToClipboard';
+import { useMainStore } from '@services/stores/useMainStore';
+import InnerHeading from '@components/InnerHeading';
+
+function BlockTable({ data }: { data: any }) {
+  const [page, setPage] = useState(1);
+  const isMobile = useMainStore((state) => state.isMobile);
+  const totalItems = data?.length || 0;
+  const itemsPerPage = 10;
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  const handleChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+  };
+
+  if (!data || data.length === 0) {
+    return (
+      <Alert severity="error" variant="outlined">
+        No blocks found.
+      </Alert>
+    );
+  }
+
+  const height = data?.height || 'no data';
+  const hash = data?.header?.hash?.data || 'no data';
+  const timestamp = data?.header?.timestamp || 'no data';
+
+  function Mobile() {
+    const col1 = 4;
+    const col2 = 8;
+
+    return (
+      <Grid container spacing={2} pl={0} pr={0} pb={2}>
+        <Grid item xs={col1}>
+          <Typography variant="body2">Height</Typography>
+        </Grid>
+        <Grid item xs={col2}>
+          <TypographyData variant="body2">{height}</TypographyData>
+        </Grid>
+        <Grid item xs={col1}>
+          <Typography variant="body2">Hash</Typography>
+        </Grid>
+        <Grid item xs={col2}>
+          <TypographyData variant="body2">
+            {shortenString(toHexString(hash), 6, 6)}
+            <CopyToClipboard copy={toHexString(hash)} />
+          </TypographyData>
+        </Grid>
+        <Grid item xs={col1}>
+          <Typography variant="body2">Timestamp</Typography>
+        </Grid>
+        <Grid item xs={col2}>
+          <TypographyData variant="body2">
+            {formatTimestamp(timestamp)}
+          </TypographyData>
+        </Grid>
+        <Grid item xs={12}>
+          <Link to={`/blocks/${height}`}>
+            <Button variant="outlined" fullWidth>
+              View Block
+            </Button>
+          </Link>
+        </Grid>
+      </Grid>
+    );
+  }
+
+  function Desktop() {
+    const col1 = 4;
+    const col2 = 4;
+    const col3 = 4;
+
+    return (
+      <>
+        <Grid container spacing={2} pl={0} pr={0} pb={2} pt={2}>
+          <Grid item xs={col1} md={col1} lg={col1}>
+            <Typography variant="body2">Height</Typography>
+          </Grid>
+          <Grid item xs={col2} md={col2} lg={col2}>
+            <Typography variant="body2">Hash</Typography>
+          </Grid>
+          <Grid item xs={col3} md={col3} lg={col3}>
+            <Typography variant="body2">Timestamp</Typography>
+          </Grid>
+          <Grid item xs={col1} md={col1} lg={col1}>
+            <TypographyData>
+              <Link to={`/blocks/${height}`}>{height}</Link>
+            </TypographyData>
+          </Grid>
+          <Grid item xs={col2} md={col2} lg={col2}>
+            <TypographyData>
+              {shortenString(toHexString(hash), 6, 6)}
+              <CopyToClipboard copy={toHexString(hash)} />
+            </TypographyData>
+          </Grid>
+          <Grid item xs={col3} md={col3} lg={col3}>
+            <TypographyData>{formatTimestamp(timestamp)}</TypographyData>
+          </Grid>
+        </Grid>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <InnerHeading>Found in Block{totalItems > 1 && 's'}:</InnerHeading>
+      {isMobile ? <Mobile /> : <Desktop />}
+      <Divider />
+      {totalItems > itemsPerPage && (
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          pt={2}
+          pb={2}
+        >
+          <Pagination
+            count={totalPages}
+            color="primary"
+            page={page}
+            onChange={handleChange}
+            siblingCount={0}
+            boundaryCount={1}
+            showFirstButton
+            showLastButton
+            variant="outlined"
+          />
+        </Box>
+      )}
+    </>
+  );
+}
+
+export default BlockTable;

--- a/src/components/Search/PayRefTable.tsx
+++ b/src/components/Search/PayRefTable.tsx
@@ -1,0 +1,325 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { useState, Fragment } from 'react';
+import { TypographyData } from '@components/StyledComponents';
+import { Typography, Grid, Divider, Pagination, Alert } from '@mui/material';
+import {
+  toHexString,
+  shortenString,
+  formatTimestamp,
+  formatXTM,
+} from '@utils/helpers';
+import { Link } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CopyToClipboard from '@components/CopyToClipboard';
+import { useMainStore } from '@services/stores/useMainStore';
+import InnerHeading from '@components/InnerHeading';
+
+function PayRefTable({ data }: { data: any }) {
+  const [page, setPage] = useState(1);
+  const isMobile = useMainStore((state) => state.isMobile);
+  const totalItems = data?.length || 0;
+  const itemsPerPage = 10;
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  const handleChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+  };
+
+  if (!data || data.length === 0) {
+    return (
+      <Alert severity="error" variant="outlined">
+        No blocks found.
+      </Alert>
+    );
+  }
+
+  function Mobile() {
+    const col1 = 4;
+    const col2 = 8;
+
+    return (
+      <Grid container spacing={2} pl={0} pr={0}>
+        {data.map((block: any, index: number) => {
+          const height = block?.block_height || 'no data';
+          const payref = block?.payment_reference_hex || 'no data';
+          const minedTimestamp = block?.mined_timestamp || 'no data';
+          const isSpent = block?.is_spent || false;
+          const minValuePromise =
+            formatXTM(block?.min_value_promise) || 'no data';
+          const commitment = toHexString(block?.commitment?.data) || 'no data';
+          const blockHash = toHexString(block?.block_hash?.data) || 'no data';
+          const spentBlockHash = toHexString(block?.spent_block_hash?.data);
+
+          return (
+            <Fragment key={index}>
+              <Grid item xs={12} key={index}>
+                <Grid container spacing={2} pl={0} pr={0} pb={2}>
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Height</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>
+                      <Link to={`/blocks/${height}?payref=${payref}`}>
+                        {height}{' '}
+                      </Link>
+                    </TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Payment Reference</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>
+                      {shortenString(payref, 6, 6)}
+                      <CopyToClipboard copy={payref} />
+                    </TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Mined Timestamp</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>
+                      {formatTimestamp(minedTimestamp)}
+                    </TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Spent</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>{isSpent ? 'Yes' : 'No'}</TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Min Value Promise</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>{minValuePromise}</TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Commitment</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>
+                      {shortenString(commitment, 6, 6)}
+                      <CopyToClipboard copy={commitment} />
+                    </TypographyData>
+                  </Grid>
+
+                  <Grid item xs={col1}>
+                    <Typography variant="body2">Block Hash</Typography>
+                  </Grid>
+                  <Grid item xs={col2}>
+                    <TypographyData>
+                      {shortenString(blockHash, 6, 6)}
+                      <CopyToClipboard copy={blockHash} />
+                    </TypographyData>
+                  </Grid>
+
+                  <Fragment>
+                    <Grid item xs={col1}>
+                      <Typography variant="body2">Spent Block Hash</Typography>
+                    </Grid>
+                    <Grid item xs={col2}>
+                      <TypographyData>
+                        {spentBlockHash?.length > 0 ? (
+                          <>
+                            {shortenString(spentBlockHash, 6, 6)}
+                            <CopyToClipboard copy={spentBlockHash} />
+                          </>
+                        ) : (
+                          'N/A'
+                        )}
+                      </TypographyData>
+                    </Grid>
+                  </Fragment>
+                </Grid>
+
+                <Grid item xs={12} pb={2}>
+                  <Link to={`/blocks/${height}?payref=${payref}`}>
+                    <Button variant="outlined" fullWidth>
+                      View Block
+                    </Button>
+                  </Link>
+                </Grid>
+                <Grid item xs={12}>
+                  <Divider />
+                </Grid>
+              </Grid>
+            </Fragment>
+          );
+        })}
+      </Grid>
+    );
+  }
+
+  function Desktop() {
+    const col1 = 1;
+    const col2 = 2;
+    const col3 = 2;
+    const col4 = 0.75;
+    const col5 = 1.75;
+    const col6 = 1.75;
+    const col7 = 1.75;
+    const col8 = 1;
+
+    return (
+      <>
+        <Grid container spacing={2} pl={0} pr={0} pb={2} pt={2}>
+          <Grid item xs={col1} md={col1} lg={col1}>
+            <Typography variant="body2">Height</Typography>
+          </Grid>
+          <Grid item xs={col2} md={col2} lg={col2}>
+            <Typography variant="body2">Payment Reference</Typography>
+          </Grid>
+          <Grid item xs={col3} md={col3} lg={col3}>
+            <Typography variant="body2">Mined Timestamp</Typography>
+          </Grid>
+          <Grid item xs={col4} md={col4} lg={col4}>
+            <Typography variant="body2">Spent</Typography>
+          </Grid>
+          <Grid item xs={col5} md={col5} lg={col5}>
+            <Typography variant="body2">Min Value Promise</Typography>
+          </Grid>
+          <Grid item xs={col6} md={col6} lg={col6}>
+            <Typography variant="body2">Commitment</Typography>
+          </Grid>
+          <Grid item xs={col7} md={col7} lg={col7}>
+            <Typography variant="body2">Block Hash</Typography>
+          </Grid>
+          <Grid item xs={col8} md={col8} lg={col8}>
+            <Typography variant="body2">Spent Block Hash</Typography>
+          </Grid>
+        </Grid>
+        <Grid container spacing={2} pl={0} pr={0} pb={2}>
+          {data
+            ?.slice((page - 1) * itemsPerPage, page * itemsPerPage)
+            .map((block: any, index: number) => {
+              const height = block?.block_height || 'no data';
+              const payref = block?.payment_reference_hex || 'no data';
+              const minedTimestamp = block?.mined_timestamp || 'no data';
+              const isSpent = block?.is_spent || false;
+              const minValuePromise =
+                formatXTM(block?.min_value_promise) || 'no data';
+              const commitment =
+                toHexString(block?.commitment?.data) || 'no data';
+              const blockHash =
+                toHexString(block?.block_hash?.data) || 'no data';
+              const spentBlockHash = toHexString(block?.spent_block_hash?.data);
+
+              return (
+                <Fragment key={index}>
+                  <Grid item xs={12}>
+                    <Divider />
+                  </Grid>
+                  <Grid item xs={col1} md={col1} lg={col1}>
+                    <TypographyData>
+                      <Link to={`/blocks/${height}?payref=${payref}`}>
+                        {height}{' '}
+                      </Link>
+                    </TypographyData>
+                  </Grid>
+                  <Grid item xs={col2} md={col2} lg={col2}>
+                    <TypographyData>
+                      {shortenString(payref, 6, 6)}
+                      <CopyToClipboard copy={payref} />
+                    </TypographyData>
+                  </Grid>
+                  <Grid item xs={col3} md={col3} lg={col3}>
+                    <TypographyData>
+                      {formatTimestamp(minedTimestamp)}
+                    </TypographyData>
+                  </Grid>
+                  <Grid item xs={col4} md={col4} lg={col4}>
+                    <TypographyData>{isSpent ? 'Yes' : 'No'}</TypographyData>
+                  </Grid>
+                  <Grid item xs={col5} md={col5} lg={col5}>
+                    <TypographyData>{minValuePromise}</TypographyData>
+                  </Grid>
+                  <Grid item xs={col6} md={col6} lg={col6}>
+                    <TypographyData>
+                      {shortenString(commitment, 6, 6)}
+                      <CopyToClipboard copy={commitment} />
+                    </TypographyData>
+                  </Grid>
+                  <Grid item xs={col7} md={col7} lg={col7}>
+                    <TypographyData>
+                      {shortenString(blockHash, 6, 6)}
+                      <CopyToClipboard copy={blockHash} />
+                    </TypographyData>
+                  </Grid>
+                  <Grid item xs={col8} md={col8} lg={col8}>
+                    <TypographyData>
+                      {spentBlockHash ? (
+                        <>
+                          {shortenString(spentBlockHash, 6, 6)}
+                          <CopyToClipboard copy={spentBlockHash} />
+                        </>
+                      ) : (
+                        'N/A'
+                      )}
+                    </TypographyData>
+                  </Grid>
+                </Fragment>
+              );
+            })}
+        </Grid>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <InnerHeading>Found in Block{totalItems > 1 && 's'}:</InnerHeading>
+      {isMobile ? <Mobile /> : <Desktop />}
+      <Divider />
+      {totalItems > itemsPerPage && (
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          pt={2}
+          pb={2}
+        >
+          <Pagination
+            count={totalPages}
+            color="primary"
+            page={page}
+            onChange={handleChange}
+            siblingCount={0}
+            boundaryCount={1}
+            showFirstButton
+            showLastButton
+            variant="outlined"
+          />
+        </Box>
+      )}
+    </>
+  );
+}
+
+export default PayRefTable;

--- a/src/components/Search/SearchBlock.tsx
+++ b/src/components/Search/SearchBlock.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button, Stack, TextField, Alert } from '@mui/material';
 import { useMainStore } from '@services/stores/useMainStore';
+import { validateHash, validateHeight } from '@utils/helpers';
 
 const SearchBlock = () => {
   const searchOpen = useMainStore((state) => state.searchOpen);
@@ -18,9 +19,8 @@ const SearchBlock = () => {
   }, [searchOpen]);
 
   const validateQuery = (query: string) => {
-    const height = parseInt(query);
-    const isHeight = !isNaN(height) && height >= 0;
-    const isHash = query.length === 64;
+    const isHeight = validateHeight(query);
+    const isHash = validateHash(query);
     return isHeight || isHash;
   };
 

--- a/src/components/Search/SearchKernel.tsx
+++ b/src/components/Search/SearchKernel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button, Stack, Alert, TextField } from '@mui/material';
 import { useMainStore } from '@services/stores/useMainStore';
+import { validateHash } from '@utils/helpers';
 
 const SearchKernel = () => {
   const [inputValue, setInputValue] = useState({ nonce: '', signature: '' });
@@ -12,7 +13,7 @@ const SearchKernel = () => {
   const navigate = useNavigate();
 
   const validateQuery = (query: string) => {
-    const isHash = query.length === 64;
+    const isHash = validateHash(query);
     return isHash;
   };
 

--- a/src/components/Search/SearchPageHeader.tsx
+++ b/src/components/Search/SearchPageHeader.tsx
@@ -22,65 +22,13 @@
 
 import { Box, Container, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { useLocation } from 'react-router-dom';
-import {
-  useSearchByPayref,
-  useGetBlockByHeightOrHash,
-} from '@services/api/hooks/useBlocks';
 import { useMediaQuery } from '@mui/material';
-import { useEffect } from 'react';
+import useSearchStatusStore from '@services/stores/useSearchStatusStore';
 
 function SearchPageHeader() {
-  const location = useLocation();
-  const params = new URLSearchParams(location.search);
-
-  const hash = params.get('hash') || '';
-
-  const { isFetching, isError, isSuccess, data } = useSearchByPayref(hash);
-  const {
-    isFetching: isBlockFetching,
-    isError: isBlockError,
-    isSuccess: isBlockSuccess,
-    data: blockData,
-  } = useGetBlockByHeightOrHash(hash);
-
+  const message = useSearchStatusStore((state) => state.message);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-
-  let status = '';
-
-  // Determine status for payref search
-  if (isFetching) {
-    status = 'Searching...';
-  } else if (isError || (isSuccess && data?.items.length === 0)) {
-    // If payref search fails, check block search
-    if (isBlockFetching) {
-      status = 'Searching...';
-    } else if (isBlockError || (isBlockSuccess && !blockData)) {
-      status = 'Not found';
-    } else if (isBlockSuccess && blockData) {
-      status = 'Block found';
-    }
-  } else if (isSuccess && data?.items.length > 0) {
-    status = `Block${data.items.length > 1 ? 's' : ''} found`;
-  }
-
-  useEffect(() => {
-    // If payref search returns exactly one result, redirect to block with payref
-    if (isSuccess && data?.items.length === 1) {
-      const blockHeight = data.items[0].block_height;
-      window.location.replace(`/blocks/${blockHeight}?payref=${hash}`);
-    }
-    // If payref search returns nothing, but block search succeeds, redirect to block
-    else if (
-      isSuccess &&
-      data?.items.length === 0 &&
-      isBlockSuccess &&
-      blockData
-    ) {
-      window.location.replace(`/blocks/${blockData.header.height}`);
-    }
-  }, [isSuccess, data, hash, isBlockSuccess, blockData]);
 
   return (
     <>
@@ -108,7 +56,7 @@ function SearchPageHeader() {
               textTransform: 'uppercase',
             }}
           >
-            {status}
+            {message || 'Searching...'}
           </Typography>
         </Box>
       </Container>

--- a/src/components/Search/SearchPageHeader.tsx
+++ b/src/components/Search/SearchPageHeader.tsx
@@ -1,0 +1,119 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { Box, Container, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { useLocation } from 'react-router-dom';
+import {
+  useSearchByPayref,
+  useGetBlockByHeightOrHash,
+} from '@services/api/hooks/useBlocks';
+import { useMediaQuery } from '@mui/material';
+import { useEffect } from 'react';
+
+function SearchPageHeader() {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+
+  const hash = params.get('hash') || '';
+
+  const { isFetching, isError, isSuccess, data } = useSearchByPayref(hash);
+  const {
+    isFetching: isBlockFetching,
+    isError: isBlockError,
+    isSuccess: isBlockSuccess,
+    data: blockData,
+  } = useGetBlockByHeightOrHash(hash);
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  let status = '';
+
+  // Determine status for payref search
+  if (isFetching) {
+    status = 'Searching...';
+  } else if (isError || (isSuccess && data?.items.length === 0)) {
+    // If payref search fails, check block search
+    if (isBlockFetching) {
+      status = 'Searching...';
+    } else if (isBlockError || (isBlockSuccess && !blockData)) {
+      status = 'Not found';
+    } else if (isBlockSuccess && blockData) {
+      status = 'Block found';
+    }
+  } else if (isSuccess && data?.items.length > 0) {
+    status = `Block${data.items.length > 1 ? 's' : ''} found`;
+  }
+
+  useEffect(() => {
+    // If payref search returns exactly one result, redirect to block with payref
+    if (isSuccess && data?.items.length === 1) {
+      const blockHeight = data.items[0].block_height;
+      window.location.replace(`/blocks/${blockHeight}?payref=${hash}`);
+    }
+    // If payref search returns nothing, but block search succeeds, redirect to block
+    else if (
+      isSuccess &&
+      data?.items.length === 0 &&
+      isBlockSuccess &&
+      blockData
+    ) {
+      window.location.replace(`/blocks/${blockData.header.height}`);
+    }
+  }, [isSuccess, data, hash, isBlockSuccess, blockData]);
+
+  return (
+    <>
+      <Container maxWidth="xl">
+        <Box
+          style={{
+            marginTop: isMobile ? theme.spacing(5) : theme.spacing(10),
+            marginBottom: isMobile ? theme.spacing(5) : theme.spacing(10),
+            color: theme.palette.text.primary,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: isMobile ? 0 : theme.spacing(1),
+          }}
+        >
+          <Typography variant="body2" style={{ textTransform: 'uppercase' }}>
+            Hash Search
+          </Typography>
+          <Typography
+            variant="h1"
+            style={{
+              fontFamily: '"DrukHeavy", sans-serif',
+              fontSize: isMobile ? 40 : 60,
+              textTransform: 'uppercase',
+            }}
+          >
+            {status}
+          </Typography>
+        </Box>
+      </Container>
+    </>
+  );
+}
+
+export default SearchPageHeader;

--- a/src/components/Search/SearchPayRef.tsx
+++ b/src/components/Search/SearchPayRef.tsx
@@ -2,9 +2,10 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button, Stack, TextField, Alert } from '@mui/material';
 import { useMainStore } from '@services/stores/useMainStore';
+import { validateHash } from '@utils/helpers';
 
 export const validatePayRefQuery = (query: string) => {
-  const isHash = query.length === 64;
+  const isHash = validateHash(query);
   return isHash;
 };
 

--- a/src/components/StyledComponents.ts
+++ b/src/components/StyledComponents.ts
@@ -69,7 +69,7 @@ export const StyledAccordion = styled(Accordion, {
 export const StyledAccordionSummary = styled(AccordionSummary, {
   shouldForwardProp: (prop) => prop !== 'isHighlighted',
 })<StyledAccordionProps>(({ theme, isHighlighted, expanded }) => ({
-  backgroundColor: isHighlighted ? '#1D1928' : 'transparent',
+  backgroundColor: isHighlighted ? '#292532' : 'transparent',
   color: isHighlighted ? '#fff' : 'inherit',
   borderRadius: expanded ? `16px 16px 0 0` : theme.shape.borderRadius,
   transition: 'background-color 0.3s ease',

--- a/src/routes/BlockExplorerPage.tsx
+++ b/src/routes/BlockExplorerPage.tsx
@@ -30,9 +30,19 @@ import HashRates from '@components/Charts/HashRates';
 import POWChart from '@components/Charts/POWChart';
 import { useTheme } from '@mui/material/styles';
 import InnerHeading from '@components/InnerHeading';
+import { useLocation } from 'react-router-dom';
 
 function BlockExplorerPage() {
   const theme = useTheme();
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const hash = params.get('hash') || '';
+
+  if (hash) {
+    // Redirect to search page if 'hash' parameter is present
+    window.location.href = `/search?hash=${hash}`;
+    return null; // Prevent further rendering
+  }
   return (
     <Grid
       container

--- a/src/routes/SearchPage.tsx
+++ b/src/routes/SearchPage.tsx
@@ -32,13 +32,14 @@ import PayRefTable from '@components/Search/PayRefTable';
 import BlockTable from '@components/Search/BlockTable';
 import useSearchStatusStore from '@services/stores/useSearchStatusStore';
 import { useEffect } from 'react';
+import { validateHash } from '@utils/helpers';
 
 function SearchPage() {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
 
   const hash = params.get('hash') || '';
-  const isHash = /^[a-fA-F0-9]{64}$/.test(hash);
+  const isHash = validateHash(hash);
 
   const setStatus = useSearchStatusStore((state) => state.setStatus);
   const setMessage = useSearchStatusStore((state) => state.setMessage);

--- a/src/routes/SearchPage.tsx
+++ b/src/routes/SearchPage.tsx
@@ -1,0 +1,109 @@
+//  Copyright 2022. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import { GradientPaper } from '@components/StyledComponents';
+import { Grid } from '@mui/material';
+import { useLocation } from 'react-router-dom';
+import {
+  useSearchByPayref,
+  useGetBlockByHeightOrHash,
+} from '@services/api/hooks/useBlocks';
+import FetchStatusCheck from '@components/FetchStatusCheck';
+import PayRefTable from '@components/Search/PayRefTable';
+import BlockTable from '@components/Search/BlockTable';
+
+function SearchPage() {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+
+  const hash = params.get('hash') || '';
+
+  const {
+    data: payrefData,
+    isFetching: isPayrefLoading,
+    isError: isPayrefError,
+    error: payrefError,
+  } = useSearchByPayref(hash);
+
+  const {
+    data: blockData,
+    isFetching: isBlockLoading,
+    isError: isBlockError,
+    error: blockError,
+  } = useGetBlockByHeightOrHash(hash);
+
+  let showFetchStatusCheck = true;
+  let isLoading = true;
+  let isError = false;
+
+  if (isPayrefLoading) {
+    showFetchStatusCheck = true;
+    isLoading = true;
+    isError = false;
+  } else if (
+    isPayrefError ||
+    (payrefData?.items.length === 0 && !isBlockLoading)
+  ) {
+    if (isBlockLoading) {
+      showFetchStatusCheck = true;
+      isLoading = true;
+      isError = false;
+    } else if (isBlockError || !blockData) {
+      showFetchStatusCheck = true;
+      isLoading = false;
+      isError = true;
+    }
+  } else {
+    showFetchStatusCheck = false;
+    isLoading = true;
+    isError = false;
+  }
+
+  if (showFetchStatusCheck) {
+    return (
+      <Grid item xs={12} md={12} lg={12}>
+        <GradientPaper>
+          <FetchStatusCheck
+            isError={isError}
+            isLoading={isLoading}
+            errorMessage={
+              payrefError?.message || blockError?.message || 'Not found'
+            }
+          />
+        </GradientPaper>
+      </Grid>
+    );
+  }
+
+  return (
+    <Grid item xs={12} md={12} lg={12}>
+      <GradientPaper>
+        {payrefData?.items.length > 0 && (
+          <PayRefTable data={payrefData?.items || []} />
+        )}
+        {blockData?.height && <BlockTable data={blockData || []} />}
+      </GradientPaper>
+    </Grid>
+  );
+}
+
+export default SearchPage;

--- a/src/services/stores/useSearchStatusStore.ts
+++ b/src/services/stores/useSearchStatusStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+interface SearchStatus {
+  isLoading: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  setStatus: (status: {
+    isLoading: boolean;
+    isError: boolean;
+    isSuccess: boolean;
+  }) => void;
+  message?: string;
+  setMessage: (message: string) => void;
+}
+
+export const useSearchStatusStore = create<SearchStatus>()((set) => ({
+  isLoading: false,
+  isError: false,
+  isSuccess: false,
+  message: '',
+  setStatus: ({ isLoading, isError, isSuccess }) =>
+    set({ isLoading, isError, isSuccess }),
+  setMessage: (message: string) => set({ message }),
+}));
+
+export default useSearchStatusStore;

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -130,6 +130,16 @@ function formatTimestamp(timestamp: any) {
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 }
 
+function validateHeight(height: string): boolean {
+  const regex = /^\d+$/;
+  return regex.test(height);
+}
+
+function validateHash(hash: string): boolean {
+  const regex = /^[a-fA-F0-9]{64}$/;
+  return regex.test(hash);
+}
+
 function formatHash(number: number, decimals: number = 1) {
   const suffixes = ['', 'K', 'M', 'G', 'T', 'P'];
   let suffixIndex = 0;
@@ -173,6 +183,8 @@ export {
   handleChangePage,
   handleChangeRowsPerPage,
   formatTimestamp,
+  validateHash,
+  validateHeight,
   formatHash,
   formatXTM,
   powCheck,


### PR DESCRIPTION
Description
---
Combines the block hash, payref hash and block number searches into one

Motivation and Context
---
It was previously in a popup dialog and users had to choose which hash they were searching for

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Search for a hash using the search input in the header or via a url as follows:
https://payref.tari-block-explore-mainnet.pages.dev/search?hash=547495e203fb82e4e90c4b7308834f135562e88d50f8268c24ead7d1725cc44c

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
