### PR TITLE
fix: update search field to use new api

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -6,7 +6,7 @@
     
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tari Block Explorer</title>
-    <script type="module" crossorigin src="/assets/index-1c1be773.js"></script>
+    <script type="module" crossorigin src="/assets/index-779f7cf5.js"></script>
     <link rel="stylesheet" href="/assets/index-eabe2859.css">
   </head>
   <body>

--- a/src/components/Blocks/__tests__/Outputs.test.tsx
+++ b/src/components/Blocks/__tests__/Outputs.test.tsx
@@ -271,12 +271,12 @@ describe('Outputs', () => {
     // Click to show search
     fireEvent.click(screen.getByLabelText(/Show search|Hide search/));
     expect(
-      screen.getByLabelText('Search by Payment Reference (PayRef)')
+      screen.getByLabelText('Search by Payment Reference or Commitment')
     ).toBeInTheDocument();
     // Click to hide search
     fireEvent.click(screen.getByLabelText(/Show search|Hide search/));
     expect(
-      screen.queryByLabelText('Search by Payment Reference (PayRef)')
+      screen.queryByLabelText('Search by Payment Reference or Commitment')
     ).not.toBeInTheDocument();
   });
 
@@ -294,7 +294,7 @@ describe('Outputs', () => {
     );
     fireEvent.click(screen.getByLabelText(/Show search|Hide search/));
     fireEvent.change(
-      screen.getByLabelText('Search by Payment Reference (PayRef)'),
+      screen.getByLabelText('Search by Payment Reference or Commitment'),
       {
         target: { value: 'short' },
       }
@@ -302,7 +302,7 @@ describe('Outputs', () => {
     fireEvent.click(screen.getByText('Search'));
     await waitFor(() => {
       expect(
-        screen.getByText('Please enter a valid PayRef.')
+        screen.getByText('Please enter a valid 64-character hash.')
       ).toBeInTheDocument();
     });
   });

--- a/src/services/api/hooks/__tests__/useBlocks.test.tsx
+++ b/src/services/api/hooks/__tests__/useBlocks.test.tsx
@@ -1,20 +1,20 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, waitFor, act } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
 
 // Mock environment variable
-vi.mock('../../helpers/jsonRpc', () => ({
+vi.mock("../../helpers/jsonRpc", () => ({
   jsonRpc: vi.fn(),
 }));
 
 // Mock environment
-Object.defineProperty(globalThis, 'import', {
-  value: { meta: { env: { VITE_ADDRESS: 'http://localhost:3000' } } },
+Object.defineProperty(globalThis, "import", {
+  value: { meta: { env: { VITE_ADDRESS: "http://localhost:3000" } } },
   writable: true,
 });
 
-const mockJsonRpc = vi.mocked(await import('../../helpers/jsonRpc')).jsonRpc;
+const mockJsonRpc = vi.mocked(await import("../../helpers/jsonRpc")).jsonRpc;
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -30,7 +30,7 @@ const createWrapper = () => {
   );
 };
 
-describe('useBlocks hooks', () => {
+describe("useBlocks hooks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -39,34 +39,32 @@ describe('useBlocks hooks', () => {
     vi.resetAllMocks();
   });
 
-  describe('useAllBlocks', () => {
-    it('should fetch all blocks data successfully', async () => {
+  describe("useAllBlocks", () => {
+    it("should fetch all blocks data successfully", async () => {
       const mockData = {
-        blocks: [{ height: 1, hash: 'abc123' }],
+        blocks: [{ height: 1, hash: "abc123" }],
         tipInfo: { metadata: { best_block_height: 1 } },
       };
       mockJsonRpc.mockResolvedValue(mockData);
 
-      const { useAllBlocks } = await import('../useBlocks');
+      const { useAllBlocks } = await import("../useBlocks");
       const { result } = renderHook(() => useAllBlocks(), {
         wrapper: createWrapper(),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-      expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/?json'
-      );
+      expect(mockJsonRpc).toHaveBeenCalledWith("https://textexplore.tari.com/?json");
       expect(result.current.data).toEqual(mockData);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.error).toBe(null);
     });
 
-    it('should handle fetch errors gracefully', async () => {
-      const mockError = new Error('Network error');
+    it("should handle fetch errors gracefully", async () => {
+      const mockError = new Error("Network error");
       mockJsonRpc.mockRejectedValue(mockError);
 
-      const { useAllBlocks } = await import('../useBlocks');
+      const { useAllBlocks } = await import("../useBlocks");
       const { result } = renderHook(() => useAllBlocks(), {
         wrapper: createWrapper(),
       });
@@ -77,10 +75,10 @@ describe('useBlocks hooks', () => {
       expect(result.current.data).toBeUndefined();
     });
 
-    it('should use correct query key for caching', async () => {
-      mockJsonRpc.mockResolvedValue({ data: 'test' });
+    it("should use correct query key for caching", async () => {
+      mockJsonRpc.mockResolvedValue({ data: "test" });
 
-      const { useAllBlocks } = await import('../useBlocks');
+      const { useAllBlocks } = await import("../useBlocks");
       const { result } = renderHook(() => useAllBlocks(), {
         wrapper: createWrapper(),
       });
@@ -93,11 +91,11 @@ describe('useBlocks hooks', () => {
 
     // Skipped: Timer-based tests with React Query can be flaky due to internal timer interactions
     // The refetchInterval: 120000 is properly configured in the hook (see useBlocks.tsx:39)
-    it.skip('should refetch data at correct interval', async () => {
+    it.skip("should refetch data at correct interval", async () => {
       vi.useFakeTimers();
-      mockJsonRpc.mockResolvedValue({ data: 'test' });
+      mockJsonRpc.mockResolvedValue({ data: "test" });
 
-      const { useAllBlocks } = await import('../useBlocks');
+      const { useAllBlocks } = await import("../useBlocks");
       renderHook(() => useAllBlocks(), {
         wrapper: createWrapper(),
       });
@@ -122,43 +120,39 @@ describe('useBlocks hooks', () => {
     });
   });
 
-  describe('useGetBlocksByParam', () => {
-    it('should fetch blocks with from and limit parameters', async () => {
+  describe("useGetBlocksByParam", () => {
+    it("should fetch blocks with from and limit parameters", async () => {
       const mockData = { blocks: [{ height: 10 }] };
       mockJsonRpc.mockResolvedValue(mockData);
 
-      const { useGetBlocksByParam } = await import('../useBlocks');
+      const { useGetBlocksByParam } = await import("../useBlocks");
       const { result } = renderHook(() => useGetBlocksByParam(10, 50), {
         wrapper: createWrapper(),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-      expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/?from=10&limit=50&json'
-      );
+      expect(mockJsonRpc).toHaveBeenCalledWith("https://textexplore.tari.com/?from=10&limit=50&json");
       expect(result.current.data).toEqual(mockData);
     });
 
-    it('should handle different parameter values', async () => {
+    it("should handle different parameter values", async () => {
       mockJsonRpc.mockResolvedValue({ blocks: [] });
 
-      const { useGetBlocksByParam } = await import('../useBlocks');
+      const { useGetBlocksByParam } = await import("../useBlocks");
       const { result } = renderHook(() => useGetBlocksByParam(0, 100), {
         wrapper: createWrapper(),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-      expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/?from=0&limit=100&json'
-      );
+      expect(mockJsonRpc).toHaveBeenCalledWith("https://textexplore.tari.com/?from=0&limit=100&json");
     });
 
-    it('should handle errors in parameterized requests', async () => {
-      mockJsonRpc.mockRejectedValue(new Error('Invalid parameters'));
+    it("should handle errors in parameterized requests", async () => {
+      mockJsonRpc.mockRejectedValue(new Error("Invalid parameters"));
 
-      const { useGetBlocksByParam } = await import('../useBlocks');
+      const { useGetBlocksByParam } = await import("../useBlocks");
       const { result } = renderHook(() => useGetBlocksByParam(-1, 0), {
         wrapper: createWrapper(),
       });
@@ -168,25 +162,19 @@ describe('useBlocks hooks', () => {
       expect(result.current.error).toBeTruthy();
     });
 
-    it('should use unique cache keys for different parameters', async () => {
+    it("should use unique cache keys for different parameters", async () => {
       mockJsonRpc.mockResolvedValue({ blocks: [] });
 
-      const { useGetBlocksByParam } = await import('../useBlocks');
+      const { useGetBlocksByParam } = await import("../useBlocks");
 
       // Render hook with different parameters
-      const { result: result1 } = renderHook(
-        () => useGetBlocksByParam(10, 50),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { result: result1 } = renderHook(() => useGetBlocksByParam(10, 50), {
+        wrapper: createWrapper(),
+      });
 
-      const { result: result2 } = renderHook(
-        () => useGetBlocksByParam(20, 50),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { result: result2 } = renderHook(() => useGetBlocksByParam(20, 50), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => {
         expect(result1.current.isSuccess).toBe(true);
@@ -195,64 +183,54 @@ describe('useBlocks hooks', () => {
 
       // Should make separate API calls for different parameters
       expect(mockJsonRpc).toHaveBeenCalledTimes(2);
-      expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/?from=10&limit=50&json'
-      );
-      expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/?from=20&limit=50&json'
-      );
+      expect(mockJsonRpc).toHaveBeenCalledWith("https://textexplore.tari.com/?from=10&limit=50&json");
+      expect(mockJsonRpc).toHaveBeenCalledWith("https://textexplore.tari.com/?from=20&limit=50&json");
     });
   });
 
-  describe('useGetBlockByHeightOrHash', () => {
-    it('should fetch block by height', async () => {
+  describe("useGetBlockByHeightOrHash", () => {
+    it("should fetch block by height", async () => {
       const mockBlockData = {
         header: { height: 123 },
         body: { outputs: [], inputs: [], kernels: [] },
       };
       mockJsonRpc.mockResolvedValue(mockBlockData);
 
-      const { useGetBlockByHeightOrHash } = await import('../useBlocks');
-      const { result } = renderHook(() => useGetBlockByHeightOrHash('123'), {
+      const { useGetBlockByHeightOrHash } = await import("../useBlocks");
+      const { result } = renderHook(() => useGetBlockByHeightOrHash("123"), {
         wrapper: createWrapper(),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-      expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/blocks/123?json',
-        'Block not found'
-      );
+      expect(mockJsonRpc).toHaveBeenCalledWith("https://textexplore.tari.com/blocks/123?json", "Block not found");
       expect(result.current.data).toEqual(mockBlockData);
     });
 
-    it('should fetch block by hash', async () => {
-      const blockHash = 'abc123def456';
+    it("should fetch block by hash", async () => {
+      const blockHash = "abc123def456";
       const mockBlockData = { header: { hash: blockHash } };
       mockJsonRpc.mockResolvedValue(mockBlockData);
 
-      const { useGetBlockByHeightOrHash } = await import('../useBlocks');
-      const { result } = renderHook(
-        () => useGetBlockByHeightOrHash(blockHash),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { useGetBlockByHeightOrHash } = await import("../useBlocks");
+      const { result } = renderHook(() => useGetBlockByHeightOrHash(blockHash), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(mockJsonRpc).toHaveBeenCalledWith(
         `https://textexplore.tari.com/blocks/${blockHash}?json`,
-        'Block not found'
+        "Block not found"
       );
       expect(result.current.data).toEqual(mockBlockData);
     });
 
-    it('should handle block not found error', async () => {
-      mockJsonRpc.mockRejectedValue(new Error('Block not found'));
+    it("should handle block not found error", async () => {
+      mockJsonRpc.mockRejectedValue(new Error("Block not found"));
 
-      const { useGetBlockByHeightOrHash } = await import('../useBlocks');
-      const { result } = renderHook(() => useGetBlockByHeightOrHash('999999'), {
+      const { useGetBlockByHeightOrHash } = await import("../useBlocks");
+      const { result } = renderHook(() => useGetBlockByHeightOrHash("999999"), {
         wrapper: createWrapper(),
       });
 
@@ -261,122 +239,101 @@ describe('useBlocks hooks', () => {
       expect(result.current.error).toBeTruthy();
     });
 
-    it('should handle empty block height', async () => {
+    it("should handle empty block height", async () => {
       mockJsonRpc.mockResolvedValue(null);
 
-      const { useGetBlockByHeightOrHash } = await import('../useBlocks');
-      const { result } = renderHook(() => useGetBlockByHeightOrHash(''), {
+      const { useGetBlockByHeightOrHash } = await import("../useBlocks");
+      const { result } = renderHook(() => useGetBlockByHeightOrHash(""), {
         wrapper: createWrapper(),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-      expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/blocks/?json',
-        'Block not found'
-      );
+      expect(mockJsonRpc).toHaveBeenCalledWith("https://textexplore.tari.com/blocks/?json", "Block not found");
     });
   });
 
-  describe('useGetPaginatedData', () => {
-    it('should fetch paginated outputs data', async () => {
-      const mockData = { outputs: [{ commitment: 'abc123' }] };
+  describe("useGetPaginatedData", () => {
+    it("should fetch paginated outputs data", async () => {
+      const mockData = { outputs: [{ commitment: "abc123" }] };
       mockJsonRpc.mockResolvedValue(mockData);
 
-      const { useGetPaginatedData } = await import('../useBlocks');
-      const { result } = renderHook(
-        () => useGetPaginatedData('123', 'outputs', 0, 10),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { useGetPaginatedData } = await import("../useBlocks");
+      const { result } = renderHook(() => useGetPaginatedData("123", "outputs", 0, 10), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/block_data/123?what=outputs&from=0&to=10&json',
-        'Block not found'
+        "https://textexplore.tari.com/block_data/123?what=outputs&from=0&to=10&json",
+        "Block not found"
       );
       expect(result.current.data).toEqual(mockData);
     });
 
-    it('should fetch paginated inputs data', async () => {
-      const mockData = { inputs: [{ output_hash: 'def456' }] };
+    it("should fetch paginated inputs data", async () => {
+      const mockData = { inputs: [{ output_hash: "def456" }] };
       mockJsonRpc.mockResolvedValue(mockData);
 
-      const { useGetPaginatedData } = await import('../useBlocks');
-      const { result } = renderHook(
-        () => useGetPaginatedData('456', 'inputs', 5, 15),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { useGetPaginatedData } = await import("../useBlocks");
+      const { result } = renderHook(() => useGetPaginatedData("456", "inputs", 5, 15), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/block_data/456?what=inputs&from=5&to=15&json',
-        'Block not found'
+        "https://textexplore.tari.com/block_data/456?what=inputs&from=5&to=15&json",
+        "Block not found"
       );
       expect(result.current.data).toEqual(mockData);
     });
 
-    it('should fetch paginated kernels data', async () => {
-      const mockData = { kernels: [{ excess: 'ghi789' }] };
+    it("should fetch paginated kernels data", async () => {
+      const mockData = { kernels: [{ excess: "ghi789" }] };
       mockJsonRpc.mockResolvedValue(mockData);
 
-      const { useGetPaginatedData } = await import('../useBlocks');
-      const { result } = renderHook(
-        () => useGetPaginatedData('789', 'kernels', 20, 30),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { useGetPaginatedData } = await import("../useBlocks");
+      const { result } = renderHook(() => useGetPaginatedData("789", "kernels", 20, 30), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/block_data/789?what=kernels&from=20&to=30&json',
-        'Block not found'
+        "https://textexplore.tari.com/block_data/789?what=kernels&from=20&to=30&json",
+        "Block not found"
       );
       expect(result.current.data).toEqual(mockData);
     });
 
-    it('should handle pagination errors', async () => {
-      mockJsonRpc.mockRejectedValue(new Error('Invalid range'));
+    it("should handle pagination errors", async () => {
+      mockJsonRpc.mockRejectedValue(new Error("Invalid range"));
 
-      const { useGetPaginatedData } = await import('../useBlocks');
-      const { result } = renderHook(
-        () => useGetPaginatedData('123', 'outputs', -1, 0),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { useGetPaginatedData } = await import("../useBlocks");
+      const { result } = renderHook(() => useGetPaginatedData("123", "outputs", -1, 0), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => expect(result.current.isError).toBe(true));
 
       expect(result.current.error).toBeTruthy();
     });
 
-    it('should use correct cache keys for different pagination params', async () => {
-      mockJsonRpc.mockResolvedValue({ data: 'test' });
+    it("should use correct cache keys for different pagination params", async () => {
+      mockJsonRpc.mockResolvedValue({ data: "test" });
 
-      const { useGetPaginatedData } = await import('../useBlocks');
+      const { useGetPaginatedData } = await import("../useBlocks");
 
       // Different block heights should use different cache keys
-      const { result: result1 } = renderHook(
-        () => useGetPaginatedData('100', 'outputs', 0, 10),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { result: result1 } = renderHook(() => useGetPaginatedData("100", "outputs", 0, 10), {
+        wrapper: createWrapper(),
+      });
 
-      const { result: result2 } = renderHook(
-        () => useGetPaginatedData('200', 'outputs', 0, 10),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { result: result2 } = renderHook(() => useGetPaginatedData("200", "outputs", 0, 10), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => {
         expect(result1.current.isSuccess).toBe(true);
@@ -387,169 +344,116 @@ describe('useBlocks hooks', () => {
     });
   });
 
-  describe('useSearchByKernel', () => {
-    it('should search by kernel nonces and signatures', async () => {
-      const mockData = { results: [{ height: 123, hash: 'abc' }] };
+  describe("useSearchByKernel", () => {
+    it("should search by kernel nonces and signatures", async () => {
+      const mockData = { results: [{ height: 123, hash: "abc" }] };
       mockJsonRpc.mockResolvedValue(mockData);
 
-      const nonces = ['nonce1', 'nonce2'];
-      const signatures = ['sig1', 'sig2'];
+      const nonces = ["nonce1", "nonce2"];
+      const signatures = ["sig1", "sig2"];
 
-      const { useSearchByKernel } = await import('../useBlocks');
-      const { result } = renderHook(
-        () => useSearchByKernel(nonces, signatures),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { useSearchByKernel } = await import("../useBlocks");
+      const { result } = renderHook(() => useSearchByKernel(nonces, signatures), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/search_kernels?nonces=nonce1,nonce2&signatures=sig1,sig2&json'
+        "https://textexplore.tari.com/search_kernels?nonces=nonce1,nonce2&signatures=sig1,sig2&json"
       );
       expect(result.current.data).toEqual(mockData);
     });
 
-    it('should handle empty arrays', async () => {
+    it("should handle empty arrays", async () => {
       const mockData = { results: [] };
       mockJsonRpc.mockResolvedValue(mockData);
 
-      const { useSearchByKernel } = await import('../useBlocks');
+      const { useSearchByKernel } = await import("../useBlocks");
       const { result } = renderHook(() => useSearchByKernel([], []), {
         wrapper: createWrapper(),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-      expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/search_kernels?nonces=&signatures=&json'
-      );
+      expect(mockJsonRpc).toHaveBeenCalledWith("https://textexplore.tari.com/search_kernels?nonces=&signatures=&json");
     });
 
-    it('should properly encode special characters in parameters', async () => {
+    it("should properly encode special characters in parameters", async () => {
       mockJsonRpc.mockResolvedValue({ results: [] });
 
-      const nonces = ['nonce+with/special=chars'];
-      const signatures = ['sig&with?special#chars'];
+      const nonces = ["nonce+with/special=chars"];
+      const signatures = ["sig&with?special#chars"];
 
-      const { useSearchByKernel } = await import('../useBlocks');
-      const { result } = renderHook(
-        () => useSearchByKernel(nonces, signatures),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { useSearchByKernel } = await import("../useBlocks");
+      const { result } = renderHook(() => useSearchByKernel(nonces, signatures), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       // Should properly encode special characters
       expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/search_kernels?nonces=nonce%2Bwith%2Fspecial%3Dchars&signatures=sig%26with%3Fspecial%23chars&json'
+        "https://textexplore.tari.com/search_kernels?nonces=nonce%2Bwith%2Fspecial%3Dchars&signatures=sig%26with%3Fspecial%23chars&json"
       );
     });
 
-    it('should handle search errors', async () => {
-      mockJsonRpc.mockRejectedValue(new Error('Search failed'));
+    it("should handle search errors", async () => {
+      mockJsonRpc.mockRejectedValue(new Error("Search failed"));
 
-      const { useSearchByKernel } = await import('../useBlocks');
-      const { result } = renderHook(
-        () => useSearchByKernel(['nonce'], ['sig']),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { useSearchByKernel } = await import("../useBlocks");
+      const { result } = renderHook(() => useSearchByKernel(["nonce"], ["sig"]), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => expect(result.current.isError).toBe(true));
 
       expect(result.current.error).toBeTruthy();
     });
 
-    it('should handle single element arrays', async () => {
+    it("should handle single element arrays", async () => {
       mockJsonRpc.mockResolvedValue({ results: [] });
 
-      const { useSearchByKernel } = await import('../useBlocks');
-      const { result } = renderHook(
-        () => useSearchByKernel(['single-nonce'], ['single-sig']),
-        {
-          wrapper: createWrapper(),
-        }
-      );
-
-      await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-      expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/search_kernels?nonces=single-nonce&signatures=single-sig&json'
-      );
-    });
-  });
-
-  describe('useSearchByPayref', () => {
-    it('should fetch outputs by payref (lowercased)', async () => {
-      const mockData = { outputs: [{ commitment: 'abc123' }] };
-      mockJsonRpc.mockResolvedValue(mockData);
-
-      const { useSearchByPayref } = await import('../useBlocks');
-      const { result } = renderHook(() => useSearchByPayref('PAYREF123'), {
+      const { useSearchByKernel } = await import("../useBlocks");
+      const { result } = renderHook(() => useSearchByKernel(["single-nonce"], ["single-sig"]), {
         wrapper: createWrapper(),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(mockJsonRpc).toHaveBeenCalledWith(
-        'https://textexplore.tari.com/search_outputs_by_payref?payref=payref123&json',
-        'PayRef not found'
+        "https://textexplore.tari.com/search_kernels?nonces=single-nonce&signatures=single-sig&json"
       );
-      expect(result.current.data).toEqual(mockData);
-    });
-
-    it('should handle payref not found error', async () => {
-      mockJsonRpc.mockRejectedValue(new Error('PayRef not found'));
-
-      const { useSearchByPayref } = await import('../useBlocks');
-      const { result } = renderHook(() => useSearchByPayref('notfound'), {
-        wrapper: createWrapper(),
-      });
-
-      await waitFor(() => expect(result.current.isError).toBe(true));
-      expect(result.current.error).toBeTruthy();
     });
   });
 
-  describe('Hook integrations', () => {
-    it('should export all expected hooks', async () => {
-      const module = await import('../useBlocks');
+  describe("Hook integrations", () => {
+    it("should export all expected hooks", async () => {
+      const module = await import("../useBlocks");
 
       expect(module.useAllBlocks).toBeDefined();
       expect(module.useGetBlocksByParam).toBeDefined();
       expect(module.useGetBlockByHeightOrHash).toBeDefined();
       expect(module.useGetPaginatedData).toBeDefined();
       expect(module.useSearchByKernel).toBeDefined();
-      expect(module.useSearchByPayref).toBeDefined();
     });
 
-    it('should handle concurrent hook calls without interference', async () => {
+    it("should handle concurrent hook calls without interference", async () => {
       mockJsonRpc.mockImplementation((url) => {
-        if (url.includes('blocks/123')) return Promise.resolve({ block: 123 });
-        if (url.includes('blocks/456')) return Promise.resolve({ block: 456 });
-        return Promise.resolve({ default: 'data' });
+        if (url.includes("blocks/123")) return Promise.resolve({ block: 123 });
+        if (url.includes("blocks/456")) return Promise.resolve({ block: 456 });
+        return Promise.resolve({ default: "data" });
       });
 
-      const { useGetBlockByHeightOrHash } = await import('../useBlocks');
+      const { useGetBlockByHeightOrHash } = await import("../useBlocks");
 
-      const { result: result1 } = renderHook(
-        () => useGetBlockByHeightOrHash('123'),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { result: result1 } = renderHook(() => useGetBlockByHeightOrHash("123"), {
+        wrapper: createWrapper(),
+      });
 
-      const { result: result2 } = renderHook(
-        () => useGetBlockByHeightOrHash('456'),
-        {
-          wrapper: createWrapper(),
-        }
-      );
+      const { result: result2 } = renderHook(() => useGetBlockByHeightOrHash("456"), {
+        wrapper: createWrapper(),
+      });
 
       await waitFor(() => {
         expect(result1.current.isSuccess).toBe(true);

--- a/src/services/api/hooks/useBlocks.tsx
+++ b/src/services/api/hooks/useBlocks.tsx
@@ -20,15 +20,15 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { useQuery } from '@tanstack/react-query';
-import { apiError } from '../helpers/types';
-import { jsonRpc } from '../helpers/jsonRpc';
+import { useQuery } from "@tanstack/react-query";
+import { apiError } from "../helpers/types";
+import { jsonRpc } from "../helpers/jsonRpc";
 
 const address = import.meta.env.VITE_ADDRESS;
 
 export const useAllBlocks = () => {
   return useQuery({
-    queryKey: ['blocks'],
+    queryKey: ["blocks"],
     queryFn: () =>
       jsonRpc(`${address}/?json`).then((resp) => {
         return resp;
@@ -42,7 +42,7 @@ export const useAllBlocks = () => {
 
 export const useGetBlocksByParam = (from: number, limit: number) => {
   return useQuery({
-    queryKey: ['blocks', from, limit],
+    queryKey: ["blocks", from, limit],
     queryFn: () =>
       jsonRpc(`${address}/?from=${from}&limit=${limit}&json`).then((resp) => {
         return resp;
@@ -57,32 +57,25 @@ export const useGetBlocksByParam = (from: number, limit: number) => {
 export const useGetBlockByHeightOrHash = (blockHeight: string) => {
   blockHeight = blockHeight.toLowerCase();
   return useQuery({
-    queryKey: ['block', blockHeight],
+    queryKey: ["block", blockHeight],
     queryFn: () =>
-      jsonRpc(`${address}/blocks/${blockHeight}?json`, 'Block not found').then(
-        (resp) => {
-          return resp;
-        }
-      ),
+      jsonRpc(`${address}/blocks/${blockHeight}?json`, "Block not found").then((resp) => {
+        return resp;
+      }),
     onError: (error: apiError) => {
       return error;
     },
   });
 };
 
-export const useGetPaginatedData = (
-  blockHeight: string,
-  what: string,
-  from: number,
-  to: number
-) => {
+export const useGetPaginatedData = (blockHeight: string, what: string, from: number, to: number) => {
   blockHeight = blockHeight.toLowerCase();
   return useQuery({
-    queryKey: ['block', blockHeight, what, from, to],
+    queryKey: ["block", blockHeight, what, from, to],
     queryFn: () =>
       jsonRpc(
         `${address}/block_data/${blockHeight}?what=${what}&from=${from.toString()}&to=${to.toString()}&json`,
-        'Block not found'
+        "Block not found"
       ).then((resp) => {
         return resp;
       }),
@@ -94,16 +87,16 @@ export const useGetPaginatedData = (
 
 export const useSearchByKernel = (nonces: string[], signatures: string[]) => {
   return useQuery({
-    queryKey: ['searchByKernel'],
+    queryKey: ["searchByKernel"],
     queryFn: () => {
-      const encodedNonces = nonces.map(encodeURIComponent).join(',');
-      const encodedSignatures = signatures.map(encodeURIComponent).join(',');
+      const encodedNonces = nonces.map(encodeURIComponent).join(",");
+      const encodedSignatures = signatures.map(encodeURIComponent).join(",");
 
-      return jsonRpc(
-        `${address}/search_kernels?nonces=${encodedNonces}&signatures=${encodedSignatures}&json`
-      ).then((resp) => {
-        return resp;
-      });
+      return jsonRpc(`${address}/search_kernels?nonces=${encodedNonces}&signatures=${encodedSignatures}&json`).then(
+        (resp) => {
+          return resp;
+        }
+      );
     },
     onError: (error: apiError) => {
       error;
@@ -111,15 +104,12 @@ export const useSearchByKernel = (nonces: string[], signatures: string[]) => {
   });
 };
 
-export const useSearchByPayref = (payref: string) => {
-  payref = payref.toLowerCase();
+export const useSearchByHashOrNumber = (hash: string) => {
+  hash = hash.toLowerCase();
   return useQuery({
-    queryKey: ['payref', payref],
+    queryKey: ["hash", hash],
     queryFn: () =>
-      jsonRpc(
-        `${address}/search_outputs_by_payref?payref=${payref}&json`,
-        'PayRef not found'
-      ).then((resp) => {
+      jsonRpc(`${address}/search_by_hash_or_height?hash_or_number=${hash}&json`, "Hash not found").then((resp) => {
         return resp;
       }),
     onError: (error: apiError) => {

--- a/src/utils/searchFunctions.ts
+++ b/src/utils/searchFunctions.ts
@@ -56,4 +56,22 @@ const payrefSearch = (payref: string, outputs: unknown[]): number | null => {
   return foundIndex !== -1 ? foundIndex : null;
 };
 
-export { kernelSearch, payrefSearch };
+const commitmentSearch = (commitment: string, outputs: unknown[]): number | null => {
+  if (!outputs) return null;
+  commitment = commitment.toLowerCase();
+
+  const foundIndex = outputs.findIndex((output) => {
+    const o = output as Record<string, unknown>;
+    const commitmentData = o.commitment as Record<string, unknown>;
+    const commitmentHex = toHexString(commitmentData.data as number[]);
+    const commitmentMatch = commitment ? commitmentHex === commitment : false;
+    if (commitment) {
+      return commitmentMatch;
+    }
+    return false;
+  });
+
+  return foundIndex !== -1 ? foundIndex : null;
+};
+
+export { kernelSearch, payrefSearch, commitmentSearch };


### PR DESCRIPTION
Description
---
Updates the search field to use the new api at `https://textexplore.tari.com/search_by_hash_or_height?hash_or_number=<hash>`
This will now be able to search by block hash, block number, commitment or payref.
It'll automatically redirect to the correct block page and highlight the payref or commitment if found.

Motivation and Context
---
The api was updated from
`https://textexplore.tari.com/search_outputs_by_payref?payref=<payref>`
to
`https://textexplore.tari.com/search_by_hash_or_height?hash_or_number=<hash>`

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Click the top search field and search for a block hash, block number, commitment or payref.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
