### PR TITLE
fix: pow algo check and chart tooltip

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -6,7 +6,7 @@
     
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tari Block Explorer</title>
-    <script type="module" crossorigin src="/assets/index-779f7cf5.js"></script>
+    <script type="module" crossorigin src="/assets/index-a7609008.js"></script>
     <link rel="stylesheet" href="/assets/index-eabe2859.css">
   </head>
   <body>

--- a/src/components/Charts/POWChart.tsx
+++ b/src/components/Charts/POWChart.tsx
@@ -20,12 +20,12 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import ReactEcharts from 'echarts-for-react';
-import { useTheme } from '@mui/material/styles';
-import { chartColor } from '@theme/colors';
-import { useAllBlocks } from '@services/api/hooks/useBlocks';
-import { Alert, Skeleton } from '@mui/material';
-import { TransparentBg } from '@components/StyledComponents';
+import ReactEcharts from "echarts-for-react";
+import { useTheme } from "@mui/material/styles";
+import { chartColor } from "@theme/colors";
+import { useAllBlocks } from "@services/api/hooks/useBlocks";
+import { Alert, Skeleton } from "@mui/material";
+import { TransparentBg } from "@components/StyledComponents";
 
 interface AlgoSplit {
   moneroRx10: number;
@@ -61,96 +61,43 @@ const ProofOfWork = () => {
   }
 
   const moneroRx = {
-    10: calculatePercentage(
-      data?.algoSplit.moneroRx10,
-      data?.algoSplit.sha3X10,
-      data?.algoSplit.tariRx10
-    )[0],
-    20: calculatePercentage(
-      data?.algoSplit.moneroRx20,
-      data?.algoSplit.sha3X20,
-      data?.algoSplit.tariRx20
-    )[0],
-    50: calculatePercentage(
-      data?.algoSplit.moneroRx50,
-      data?.algoSplit.sha3X50,
-      data?.algoSplit.tariRx50
-    )[0],
-    100: calculatePercentage(
-      data?.algoSplit.moneroRx100,
-      data?.algoSplit.sha3X100,
-      data?.algoSplit.tariRx100
-    )[0],
+    10: calculatePercentage(data?.algoSplit.moneroRx10, data?.algoSplit.sha3X10, data?.algoSplit.tariRx10)[0],
+    20: calculatePercentage(data?.algoSplit.moneroRx20, data?.algoSplit.sha3X20, data?.algoSplit.tariRx20)[0],
+    50: calculatePercentage(data?.algoSplit.moneroRx50, data?.algoSplit.sha3X50, data?.algoSplit.tariRx50)[0],
+    100: calculatePercentage(data?.algoSplit.moneroRx100, data?.algoSplit.sha3X100, data?.algoSplit.tariRx100)[0],
   };
 
   const sha3X = {
-    10: calculatePercentage(
-      data?.algoSplit.moneroRx10,
-      data?.algoSplit.sha3X10,
-      data?.algoSplit.tariRx10
-    )[1],
-    20: calculatePercentage(
-      data?.algoSplit.moneroRx20,
-      data?.algoSplit.sha3X20,
-      data?.algoSplit.tariRx20
-    )[1],
-    50: calculatePercentage(
-      data?.algoSplit.moneroRx50,
-      data?.algoSplit.sha3X50,
-      data?.algoSplit.tariRx50
-    )[1],
-    100: calculatePercentage(
-      data?.algoSplit.moneroRx100,
-      data?.algoSplit.sha3X100,
-      data?.algoSplit.tariRx100
-    )[1],
+    10: calculatePercentage(data?.algoSplit.moneroRx10, data?.algoSplit.sha3X10, data?.algoSplit.tariRx10)[1],
+    20: calculatePercentage(data?.algoSplit.moneroRx20, data?.algoSplit.sha3X20, data?.algoSplit.tariRx20)[1],
+    50: calculatePercentage(data?.algoSplit.moneroRx50, data?.algoSplit.sha3X50, data?.algoSplit.tariRx50)[1],
+    100: calculatePercentage(data?.algoSplit.moneroRx100, data?.algoSplit.sha3X100, data?.algoSplit.tariRx100)[1],
   };
   const tariRx = {
-    10: calculatePercentage(
-      data?.algoSplit.moneroRx10,
-      data?.algoSplit.sha3X10,
-      data?.algoSplit.tariRx10
-    )[2],
-    20: calculatePercentage(
-      data?.algoSplit.moneroRx20,
-      data?.algoSplit.sha3X20,
-      data?.algoSplit.tariRx20
-    )[2],
-    50: calculatePercentage(
-      data?.algoSplit.moneroRx50,
-      data?.algoSplit.sha3X50,
-      data?.algoSplit.tariRx50
-    )[2],
-    100: calculatePercentage(
-      data?.algoSplit.moneroRx100,
-      data?.algoSplit.sha3X100,
-      data?.algoSplit.tariRx100
-    )[2],
+    10: calculatePercentage(data?.algoSplit.moneroRx10, data?.algoSplit.sha3X10, data?.algoSplit.tariRx10)[2],
+    20: calculatePercentage(data?.algoSplit.moneroRx20, data?.algoSplit.sha3X20, data?.algoSplit.tariRx20)[2],
+    50: calculatePercentage(data?.algoSplit.moneroRx50, data?.algoSplit.sha3X50, data?.algoSplit.tariRx50)[2],
+    100: calculatePercentage(data?.algoSplit.moneroRx100, data?.algoSplit.sha3X100, data?.algoSplit.tariRx100)[2],
   };
 
   const option = {
     tooltip: {
-      trigger: 'axis',
+      trigger: "axis",
       axisPointer: {
-        type: 'shadow',
+        type: "shadow",
       },
-      formatter: function (
-        params: Array<{ name: string; color: string; value: number }>
-      ) {
-        const moneroBlocks =
-          data?.algoSplit[`moneroRx${params[0].name}` as keyof AlgoSplit];
-        const shaBlocks =
-          data?.algoSplit[`sha3X${params[0].name}` as keyof AlgoSplit];
-        const tariBlocks =
-          data?.algoSplit[`tariRx${params[0].name}` as keyof AlgoSplit];
+      formatter: function (params: Array<{ name: string; color: string; value: number }>) {
+        const moneroBlocks = data?.algoSplit[`moneroRx${params[0].name}` as keyof AlgoSplit];
+        const shaBlocks = data?.algoSplit[`sha3X${params[0].name}` as keyof AlgoSplit];
+        const tariBlocks = data?.algoSplit[`tariRx${params[0].name}` as keyof AlgoSplit];
         const moneroColor = params[0].color;
         const shaColor = params[1].color;
         const tariColor = params[2].color;
         return `
           <b>In the last ${params[0].name} blocks:</b><br />
-          <span style="color:${moneroColor};"></span>RandomX: ${moneroBlocks} blocks (${params[0].value}%)<br />
-          <span style="color:${shaColor};"></span>Sha 3: ${shaBlocks} blocks (${params[1].value}%)
-          <span style="color:${tariColor};"></span>Tari RandomX: ${tariBlocks} blocks (${params[2].value}%)
+          <span style="display:inline-block;width:8px;height:8px;background-color:${moneroColor};border-radius:50%;margin-right:5px;"></span>RandomX: ${moneroBlocks} ${moneroBlocks === 1 ? 'block' : 'blocks'} (${params[0].value}%)<br />
+          <span style="display:inline-block;width:8px;height:8px;background-color:${shaColor};border-radius:50%;margin-right:5px;"></span>Sha 3: ${shaBlocks} ${shaBlocks === 1 ? 'block' : 'blocks'} (${params[1].value}%)<br />
+          <span style="display:inline-block;width:8px;height:8px;background-color:${tariColor};border-radius:50%;margin-right:5px;"></span>Tari RandomX: ${tariBlocks} ${tariBlocks === 1 ? 'block' : 'blocks'} (${params[2].value}%)
         `;
       },
     },
@@ -162,20 +109,20 @@ const ProofOfWork = () => {
     },
     color: [chartColor[4], chartColor[3], chartColor[2]],
     grid: {
-      left: '2%',
-      right: '2%',
-      bottom: '15%',
-      top: '5%',
+      left: "2%",
+      right: "2%",
+      bottom: "15%",
+      top: "5%",
       containLabel: true,
     },
     xAxis: {
-      type: 'value',
+      type: "value",
       label: {
         color: theme.palette.text.primary,
         label: {
           show: true,
         },
-        text: 'Percentage',
+        text: "Percentage",
       },
       axisLine: {
         lineStyle: {
@@ -189,11 +136,11 @@ const ProofOfWork = () => {
       },
     },
     yAxis: {
-      type: 'category',
+      type: "category",
       axisLabel: {
-        formatter: 'Last {value} blocks',
+        formatter: "Last {value} blocks",
       },
-      data: ['100', '50', '20', '10'],
+      data: ["100", "50", "20", "10"],
       axisLine: {
         lineStyle: {
           color: theme.palette.text.primary,
@@ -202,41 +149,41 @@ const ProofOfWork = () => {
     },
     series: [
       {
-        name: 'RandomX',
-        type: 'bar',
-        stack: 'total',
+        name: "RandomX",
+        type: "bar",
+        stack: "total",
         label: {
           show: true,
           formatter: `{c}%`,
         },
         emphasis: {
-          focus: 'series',
+          focus: "series",
         },
         data: [moneroRx[100], moneroRx[50], moneroRx[20], moneroRx[10]],
       },
       {
-        name: 'Sha 3',
-        type: 'bar',
-        stack: 'total',
+        name: "Sha 3",
+        type: "bar",
+        stack: "total",
         label: {
           show: true,
           formatter: `{c}%`,
         },
         emphasis: {
-          focus: 'series',
+          focus: "series",
         },
         data: [sha3X[100], sha3X[50], sha3X[20], sha3X[10]],
       },
       {
-        name: 'Tari RandomX',
-        type: 'bar',
-        stack: 'total',
+        name: "Tari RandomX",
+        type: "bar",
+        stack: "total",
         label: {
           show: true,
           formatter: `{c}%`,
         },
         emphasis: {
-          focus: 'series',
+          focus: "series",
         },
         data: [tariRx[100], tariRx[50], tariRx[20], tariRx[10]],
       },

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -20,7 +20,7 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { ChangeEvent } from 'react';
+import { ChangeEvent } from "react";
 
 const renderJson = (json: unknown): React.ReactNode => {
   if (Array.isArray(json)) {
@@ -38,11 +38,11 @@ const renderJson = (json: unknown): React.ReactNode => {
         ],
       </>
     );
-  } else if (typeof json === 'object' && json !== null) {
+  } else if (typeof json === "object" && json !== null) {
     const obj = json as Record<string, unknown>;
     return (
       <>
-        {'{'}
+        {"{"}
         <ul>
           {Object.keys(obj).map((key) => (
             <li key={key}>
@@ -50,24 +50,23 @@ const renderJson = (json: unknown): React.ReactNode => {
             </li>
           ))}
         </ul>
-        {'}'}
+        {"}"}
       </>
     );
   } else {
-    if (typeof json === 'string')
-      return <span className="string">"{json}"</span>;
+    if (typeof json === "string") return <span className="string">"{json}"</span>;
     return <span className="other">{String(json)}</span>;
   }
 };
 
 function removeTagged(obj: unknown): unknown {
   if (obj === undefined) {
-    return 'undefined';
+    return "undefined";
   }
-  if (typeof obj === 'object' && obj !== null) {
+  if (typeof obj === "object" && obj !== null) {
     const rec = obj as Record<string, unknown>;
-    if (rec['@@TAGGED@@'] !== undefined) {
-      const tagged = rec['@@TAGGED@@'] as unknown[];
+    if (rec["@@TAGGED@@"] !== undefined) {
+      const tagged = rec["@@TAGGED@@"] as unknown[];
       return tagged[1];
     }
   }
@@ -77,46 +76,41 @@ function removeTagged(obj: unknown): unknown {
 function toHexString(byteArray: unknown): string {
   if (Array.isArray(byteArray)) {
     return Array.from(byteArray, function (byte) {
-      return ('0' + (byte & 0xff).toString(16)).slice(-2);
-    }).join('');
+      return ("0" + (byte & 0xff).toString(16)).slice(-2);
+    }).join("");
   }
   if (byteArray === undefined) {
-    return 'undefined';
+    return "undefined";
   }
   if (
-    typeof byteArray === 'object' &&
+    typeof byteArray === "object" &&
     byteArray !== null &&
-    (byteArray as Record<string, unknown>)['@@TAGGED@@'] !== undefined
+    (byteArray as Record<string, unknown>)["@@TAGGED@@"] !== undefined
   ) {
-    const tagged = (byteArray as Record<string, unknown>)[
-      '@@TAGGED@@'
-    ] as unknown[];
+    const tagged = (byteArray as Record<string, unknown>)["@@TAGGED@@"] as unknown[];
     return toHexString(tagged[1] as number[]);
   }
   // Only allow arrays, tagged objects, or undefined. All else unsupported.
-  return 'Unsupported type';
+  return "Unsupported type";
 }
 
 function fromHexString(hexString: string) {
   const res: number[] = [];
   for (let i = 0; i < hexString.length; i += 2) {
-    res.push(Number('0x' + hexString.substring(i, i + 2)));
+    res.push(Number("0x" + hexString.substring(i, i + 2)));
   }
   return res;
 }
 
 function shortenString(string: string, start: number = 8, end: number = 8) {
-  return string.substring(0, start) + '...' + string.slice(-end);
+  return string.substring(0, start) + "..." + string.slice(-end);
 }
 
 function emptyRows(page: number, rowsPerPage: number, array: unknown[]) {
   return page > 0 ? Math.max(0, (1 + page) * rowsPerPage - array.length) : 0;
 }
 
-function handleChangePage(
-  newPage: number,
-  setPage: React.Dispatch<React.SetStateAction<number>>
-) {
+function handleChangePage(newPage: number, setPage: React.Dispatch<React.SetStateAction<number>>) {
   setPage(newPage);
 }
 
@@ -133,11 +127,11 @@ function formatTimestamp(timestamp: number) {
   const date = new Date(timestamp * 1000);
 
   const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  const seconds = String(date.getSeconds()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
 
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 }
@@ -153,23 +147,23 @@ function validateHash(hash: string): boolean {
 }
 
 function formatHash(number: number, decimals: number = 1) {
-  const suffixes = ['', 'K', 'M', 'G', 'T', 'P'];
+  const suffixes = ["", "K", "M", "G", "T", "P"];
   let suffixIndex = 0;
   while (number >= 1000 && suffixIndex < suffixes.length - 1) {
     number /= 1000;
     suffixIndex++;
   }
-  return number.toFixed(decimals) + suffixes[suffixIndex] + 'H';
+  return number.toFixed(decimals) + suffixes[suffixIndex] + "H";
 }
 
 function formatNumber(number: number | undefined | null, decimals: number = 2) {
   if (number === undefined || number === null) {
-    return 'N/A';
+    return "N/A";
   }
   if (number < 1000000) {
     return number.toLocaleString();
   }
-  const suffixes = ['', 'K', 'M', 'B', 'T'];
+  const suffixes = ["", "K", "M", "B", "T"];
   let suffixIndex = 0;
   while (number >= 1000 && suffixIndex < suffixes.length - 1) {
     number /= 1000;
@@ -179,23 +173,26 @@ function formatNumber(number: number | undefined | null, decimals: number = 2) {
 }
 
 function formatXTM(amount: number): string {
-  return amount / 1_000_000 + ' XTM';
+  return amount / 1_000_000 + " XTM";
 }
 
-function powCheck(num: string): string {
-  let powText = '';
+function powCheck(num: string | number): string {
+  if (typeof num === "number") {
+    num = num.toString();
+  }
+  let powText = "";
   switch (num) {
-    case '0':
-      powText = 'RandomX (Merge Mined)';
+    case "0":
+      powText = "RandomX (Merge Mined)";
       break;
-    case '1':
-      powText = 'SHA3x';
+    case "1":
+      powText = "SHA3x";
       break;
-    case '2':
-      powText = 'RandomX';
+    case "2":
+      powText = "RandomX";
       break;
     default:
-      powText = 'Unknown';
+      powText = "Unknown";
       break;
   }
   return powText;


### PR DESCRIPTION
Description
---
Changed the powCheck function to work with both numbers and strings, as the api is now returning a number, where it used to be a string for the pow in the block header.
Also improved the tooltip on the pow chart on the homepage, so it has better spacing and shows a little dot with the colour next to the label.

Motivation and Context
---
The Proof of Work algo on the block page was displaying as "Unknown" due to the api change.

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Click on any block and confirm that the proof of work is not displaying "Unknown".

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
