### PR TITLE
chore: adjust c29 precision

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -6,7 +6,7 @@
     
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tari Block Explorer</title>
-    <script type="module" crossorigin src="/assets/index-61731008.js"></script>
+    <script type="module" crossorigin src="/assets/index-7754eed9.js"></script>
     <link rel="stylesheet" href="/assets/index-eabe2859.css">
   </head>
   <body>

--- a/src/components/Charts/HashRates.tsx
+++ b/src/components/Charts/HashRates.tsx
@@ -108,7 +108,7 @@ const HashRates: React.FC<HashRatesProps> = ({ type }) => {
       formatter: (params: Array<{ seriesName: string; value: number; dataIndex: number }>) => {
         const tooltipContent = params.map((param: { seriesName: string; value: number; dataIndex: number }) => {
           const seriesName = param.seriesName;
-          const value = type === "Cuckaroo29" ? formatC29(param.value, 2) : formatHash(param.value, 2);
+          const value = type === "Cuckaroo29" ? param.value.toFixed(1) + "g" : formatHash(param.value, 2);
           return `${seriesName}: ${value}`;
         });
         const blockNumber = display[params[0].dataIndex].blockNumber;
@@ -164,7 +164,7 @@ const HashRates: React.FC<HashRatesProps> = ({ type }) => {
         },
       },
       axisLabel: {
-        formatter: (value: number) => (type === "Cuckaroo29" ? formatC29(value, 0) : formatHash(value, 0)),
+        formatter: (value: number) => (type === "Cuckaroo29" ? formatC29(value, 1) : formatHash(value, 0)),
       },
     },
     dataZoom: [

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -176,11 +176,11 @@ function formatXTM(amount: number): string {
   return amount / 1_000_000 + " XTM";
 }
 
-function formatC29(hashRateGps: number, precision: number = 0): string {
+function formatC29(hashRateGps: number, precision: number = 2): string {
   if (hashRateGps >= 1000) {
     return `${(hashRateGps / 1000).toFixed(precision)}Kg`;
   }
-  return `${hashRateGps.toFixed(precision)}g`;
+  return `${hashRateGps.toFixed(0)}g`;
 }
 
 function powCheck(num: string | number): string {


### PR DESCRIPTION
Description
---
Adjusted the precision of the C29 graphs in the topbar and hash rate chart.
Topbar now shows 2 decimals on Kg and the hash rate chart shows one decimal - otherwise the chart y-axis label was just showing 4Kg for all the values.

Motivation and Context
---
Better UX

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
