### PR TITLE
fix: kernelsearch

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -6,7 +6,7 @@
     
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tari Block Explorer</title>
-    <script type="module" crossorigin src="/assets/index-7754eed9.js"></script>
+    <script type="module" crossorigin src="/assets/index-67d78e8f.js"></script>
     <link rel="stylesheet" href="/assets/index-eabe2859.css">
   </head>
   <body>

--- a/src/components/KernelSearch/BlockTable.tsx
+++ b/src/components/KernelSearch/BlockTable.tsx
@@ -20,29 +20,26 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { useState, Fragment } from 'react';
-import type { Block } from '@types';
-import { TypographyData } from '@components/StyledComponents';
-import { Typography, Grid, Divider, Pagination } from '@mui/material';
-import { toHexString, shortenString, formatTimestamp } from '@utils/helpers';
-import { Link } from 'react-router-dom';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import CopyToClipboard from '@components/CopyToClipboard';
-import { useMainStore } from '@services/stores/useMainStore';
-import InnerHeading from '@components/InnerHeading';
-import { powCheck } from '@utils/helpers';
+import { useState, Fragment } from "react";
+import { TypographyData } from "@components/StyledComponents";
+import { Typography, Grid, Divider, Pagination } from "@mui/material";
+import { toHexString, shortenString } from "@utils/helpers";
+import { Link } from "react-router-dom";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import CopyToClipboard from "@components/CopyToClipboard";
+import { useMainStore } from "@services/stores/useMainStore";
+import InnerHeading from "@components/InnerHeading";
+import { KernelSearchItem } from "@types";
 
-interface BlockTableProps {
-  data: Array<{ block: Block }>;
-}
-
-function BlockTable({ data }: BlockTableProps) {
+function BlockTable({ data }: { data: KernelSearchItem[] | undefined }) {
   const [page, setPage] = useState(1);
   const isMobile = useMainStore((state) => state.isMobile);
   const totalItems = data?.length || 0;
   const itemsPerPage = 10;
   const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  console.log("BlockTable data:", data);
 
   const handleChange = (_event: React.ChangeEvent<unknown>, value: number) => {
     setPage(value);
@@ -54,97 +51,51 @@ function BlockTable({ data }: BlockTableProps) {
 
     return (
       <Grid container spacing={2} pl={0} pr={0}>
-        {data
-          ?.slice((page - 1) * itemsPerPage, page * itemsPerPage)
-          .map(({ block }: { block: Block }, index: number) => {
-            const height = block?.header?.height || 'no data';
-            const timestamp = block?.header?.timestamp || 'no data';
-            const hash = block?.header?.hash?.data || 'no data';
-            const pow = block?.header?.pow?.pow_algo?.toString() || 'no data';
-            const kernels = block?.body.kernels.length || 'no data';
-            const outputs = block?.body.outputs.length || 'no data';
+        {data?.slice((page - 1) * itemsPerPage, page * itemsPerPage).map((block: KernelSearchItem, index: number) => {
+          const height = block?.block_height || "no data";
+          const hash = block?.hash?.data || "no data";
 
-            return (
-              <Fragment key={index}>
-                <Grid item xs={col1}>
-                  <Typography variant="body2">Height</Typography>
-                </Grid>
-                <Grid item xs={col2}>
-                  <TypographyData>
-                    <Link to={`/blocks/${height}`}>
-                      {height.toLocaleString('en-US')}{' '}
-                    </Link>
-                  </TypographyData>
-                </Grid>
+          return (
+            <Fragment key={index}>
+              <Grid item xs={col1}>
+                <Typography variant="body2">Height</Typography>
+              </Grid>
+              <Grid item xs={col2}>
+                <TypographyData>
+                  <Link to={`/blocks/${height}`}>{parseInt(height).toLocaleString("en-US")}</Link>
+                </TypographyData>
+              </Grid>
 
-                <Grid item xs={col1}>
-                  <Typography variant="body2">Timestamp</Typography>
-                </Grid>
-                <Grid item xs={col2}>
-                  <TypographyData>
-                    {typeof timestamp === 'number'
-                      ? formatTimestamp(timestamp)
-                      : 'no data'}
-                  </TypographyData>
-                </Grid>
+              <Grid item xs={col1}>
+                <Typography variant="body2">Hash</Typography>
+              </Grid>
+              <Grid item xs={col2}>
+                <TypographyData>
+                  {shortenString(toHexString(hash), 6, 6)}
+                  <CopyToClipboard copy={toHexString(hash)} />
+                </TypographyData>
+              </Grid>
 
-                <Grid item xs={col1}>
-                  <Typography variant="body2">Proof of Work</Typography>
-                </Grid>
-                <Grid item xs={col2}>
-                  <TypographyData>
-                    {pow === 'no data' ? 'no data' : powCheck(pow)}
-                  </TypographyData>
-                </Grid>
-
-                <Grid item xs={col1}>
-                  <Typography variant="body2">Hash</Typography>
-                </Grid>
-                <Grid item xs={col2}>
-                  <TypographyData>
-                    {shortenString(toHexString(hash), 6, 6)}
-                    <CopyToClipboard copy={toHexString(hash)} />
-                  </TypographyData>
-                </Grid>
-
-                <Grid item xs={col1}>
-                  <Typography variant="body2">Kernels</Typography>
-                </Grid>
-                <Grid item xs={col2}>
-                  <TypographyData>{kernels}</TypographyData>
-                </Grid>
-
-                <Grid item xs={col1}>
-                  <Typography variant="body2">Outputs</Typography>
-                </Grid>
-                <Grid item xs={col2}>
-                  <TypographyData>{outputs}</TypographyData>
-                </Grid>
-
-                <Grid item xs={12} pb={2}>
-                  <Link to={`/blocks/${height}`}>
-                    <Button variant="outlined" fullWidth>
-                      View Block
-                    </Button>
-                  </Link>
-                </Grid>
-                <Grid item xs={12}>
-                  <Divider />
-                </Grid>
-              </Fragment>
-            );
-          })}
+              <Grid item xs={12} pb={2}>
+                <Link to={`/blocks/${height}`}>
+                  <Button variant="outlined" fullWidth>
+                    View Block
+                  </Button>
+                </Link>
+              </Grid>
+              <Grid item xs={12}>
+                <Divider />
+              </Grid>
+            </Fragment>
+          );
+        })}
       </Grid>
     );
   }
 
   function Desktop() {
-    const col1 = 2;
-    const col2 = 3;
-    const col3 = 2;
-    const col4 = 3;
-    const col5 = 1;
-    const col6 = 1;
+    const col1 = 3;
+    const col4 = 9;
 
     return (
       <>
@@ -152,96 +103,34 @@ function BlockTable({ data }: BlockTableProps) {
           <Grid item xs={col1} md={col1} lg={col1}>
             <Typography variant="body2">Height</Typography>
           </Grid>
-          <Grid item xs={col2} md={col2} lg={col2}>
-            <Typography variant="body2">Time</Typography>
-          </Grid>
-          <Grid item xs={col3} md={col3} lg={col3}>
-            <Typography variant="body2">Proof of Work</Typography>
-          </Grid>
           <Grid item xs={col4} md={col4} lg={col4}>
             <Typography variant="body2">Hash</Typography>
           </Grid>
-          <Grid
-            item
-            xs={col5}
-            md={col5}
-            lg={col5}
-            style={{ textAlign: 'center' }}
-          >
-            <Typography variant="body2">Kernels</Typography>
-          </Grid>
-          <Grid
-            item
-            xs={col6}
-            md={col6}
-            lg={col6}
-            style={{ textAlign: 'center' }}
-          >
-            <Typography variant="body2">Outputs</Typography>
-          </Grid>
         </Grid>
         <Grid container spacing={2} pl={0} pr={0} pb={2}>
-          {data
-            ?.slice((page - 1) * itemsPerPage, page * itemsPerPage)
-            .map(({ block }: { block: Block }, index: number) => {
-              const height = block?.header?.height || 'no data';
-              const timestamp = block?.header?.timestamp || 'no data';
-              const hash = block?.header?.hash?.data || 'no data';
-              const pow = block?.header?.pow?.pow_algo?.toString() || 'no data';
-              const kernels = block?.body.kernels.length || 'no data';
-              const outputs = block?.body.outputs.length || 'no data';
+          {data?.slice((page - 1) * itemsPerPage, page * itemsPerPage).map((block: KernelSearchItem, index: number) => {
+            const height = block?.block_height || "no data";
+            const hash = block?.hash?.data || "no data";
 
-              return (
-                <Fragment key={index}>
-                  <Grid item xs={12}>
-                    <Divider />
-                  </Grid>
-                  <Grid item xs={col1} md={col1} lg={col1}>
-                    <TypographyData>
-                      <Link to={`/blocks/${height}`}>
-                        {height.toLocaleString('en-US')}
-                      </Link>
-                    </TypographyData>
-                  </Grid>
-                  <Grid item xs={col2} md={col2} lg={col2}>
-                    <TypographyData>
-                      {typeof timestamp === 'number'
-                        ? formatTimestamp(timestamp)
-                        : 'no data'}
-                    </TypographyData>
-                  </Grid>
-                  <Grid item xs={col3} md={col3} lg={col3}>
-                    <TypographyData>
-                      {pow === 'no data' ? 'no data' : powCheck(pow)}
-                    </TypographyData>
-                  </Grid>
-                  <Grid item xs={col4} md={col4} lg={col4}>
-                    <TypographyData>
-                      {shortenString(toHexString(hash))}
-                      <CopyToClipboard copy={toHexString(hash)} />
-                    </TypographyData>
-                  </Grid>
-                  <Grid
-                    item
-                    xs={col5}
-                    md={col5}
-                    lg={col5}
-                    style={{ textAlign: 'center' }}
-                  >
-                    <TypographyData>{kernels}</TypographyData>
-                  </Grid>
-                  <Grid
-                    item
-                    xs={col6}
-                    md={col6}
-                    lg={col6}
-                    style={{ textAlign: 'center' }}
-                  >
-                    <TypographyData>{outputs}</TypographyData>
-                  </Grid>
-                </Fragment>
-              );
-            })}
+            return (
+              <Fragment key={index}>
+                <Grid item xs={12}>
+                  <Divider />
+                </Grid>
+                <Grid item xs={col1} md={col1} lg={col1}>
+                  <TypographyData>
+                    <Link to={`/blocks/${height}`}>{parseInt(height).toLocaleString("en-US")}</Link>
+                  </TypographyData>
+                </Grid>
+                <Grid item xs={col4} md={col4} lg={col4}>
+                  <TypographyData>
+                    {shortenString(toHexString(hash))}
+                    <CopyToClipboard copy={toHexString(hash)} />
+                  </TypographyData>
+                </Grid>
+              </Fragment>
+            );
+          })}
         </Grid>
       </>
     );
@@ -249,17 +138,11 @@ function BlockTable({ data }: BlockTableProps) {
 
   return (
     <>
-      <InnerHeading>Found in Block{totalItems > 1 && 's'}:</InnerHeading>
+      <InnerHeading>Found in Block{totalItems > 1 && "s"}:</InnerHeading>
       {isMobile ? <Mobile /> : <Desktop />}
       <Divider />
       {totalItems > itemsPerPage && (
-        <Box
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          pt={2}
-          pb={2}
-        >
+        <Box display="flex" justifyContent="center" alignItems="center" pt={2} pb={2}>
           <Pagination
             count={totalPages}
             color="primary"

--- a/src/components/KernelSearch/__tests__/BlockTable.test.tsx
+++ b/src/components/KernelSearch/__tests__/BlockTable.test.tsx
@@ -29,20 +29,20 @@ vi.mock('@components/InnerHeading', () => ({
 vi.mock('@utils/helpers', () => ({
   toHexString: vi.fn((data: unknown) => {
     if (!data || data === 'no data') return 'no data';
+    if (Array.isArray(data)) {
+      return `hex_${data.join(',')}`;
+    }
     return `hex_${data}`;
   }),
   shortenString: vi.fn(
-    (str: string, start: number, end: number) =>
-      `${str.substring(0, start)}...${str.substring(str.length - end)}`
+    (str: string, start?: number, end?: number) => {
+      if (!str || str === 'no data') return 'no data';
+      if (start !== undefined && end !== undefined) {
+        return `${str.substring(0, start)}...${str.substring(str.length - end)}`;
+      }
+      return str.length > 16 ? `${str.substring(0, 8)}...${str.substring(str.length - 8)}` : str;
+    }
   ),
-  formatTimestamp: vi.fn((timestamp: unknown) => {
-    if (!timestamp || timestamp === 'no data') return 'no data';
-    return `formatted_${timestamp}`;
-  }),
-  powCheck: vi.fn((algo: unknown) => {
-    if (!algo || algo === 'no data') return 'no data';
-    return `pow_${algo}`;
-  }),
 }));
 
 vi.mock('@mui/material', () => ({
@@ -215,203 +215,116 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => {
 describe('BlockTable', () => {
   let mockUseMainStore: ReturnType<typeof vi.fn>;
   let mockToHexString: ReturnType<typeof vi.fn>;
-  let mockFormatTimestamp: ReturnType<typeof vi.fn>;
-  let mockPowCheck: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     const { useMainStore } = await import('@services/stores/useMainStore');
-    const { toHexString, formatTimestamp, powCheck } = await import(
-      '@utils/helpers'
-    );
+    const { toHexString } = await import('@utils/helpers');
     mockUseMainStore = vi.mocked(useMainStore);
     mockToHexString = vi.mocked(toHexString);
-    mockFormatTimestamp = vi.mocked(formatTimestamp);
-    mockPowCheck = vi.mocked(powCheck);
   });
 
   const mockSearchResults = [
     {
-      block: {
-        header: {
-          height: 12345,
-          timestamp: 1640995200,
-          hash: {
-            data: [
-              230, 160, 204, 44, 173, 230, 204, 173, 53, 91, 78, 10, 8, 168, 2,
-              174, 164, 156, 16, 1, 133, 148, 15, 200, 171, 69, 101, 117, 185,
-              116, 123, 184,
-            ],
-          },
-          pow: { pow_algo: 1 },
-          version: 1,
-          prev_hash: {
-            data: [
-              230, 160, 204, 44, 173, 230, 204, 173, 53, 91, 78, 10, 8, 168, 2,
-              174, 164, 156, 16, 1, 133, 148, 15, 200, 171, 69, 101, 117, 185,
-              116, 123, 185,
-            ],
-          },
-          nonce: 123456,
-          output_mr: {
-            data: [
-              230, 160, 204, 44, 173, 230, 204, 173, 53, 91, 78, 10, 8, 168, 2,
-              174, 164, 156, 16, 1, 133, 148, 15, 200, 171, 69, 101, 117, 185,
-              116, 123, 186,
-            ],
-          },
-          validator_node_mr: {
-            data: [
-              230, 160, 204, 44, 173, 230, 204, 173, 53, 91, 78, 10, 8, 168, 2,
-              174, 164, 156, 16, 1, 133, 148, 15, 200, 171, 69, 101, 117, 185,
-              116, 123, 187,
-            ],
-          },
-          kernel_mr: {
-            data: [
-              230, 160, 204, 44, 173, 230, 204, 173, 53, 91, 78, 10, 8, 168, 2,
-              174, 164, 156, 16, 1, 133, 148, 15, 200, 171, 69, 101, 117, 185,
-              116, 123, 188,
-            ],
-          },
-          input_mr: {
-            data: [
-              230, 160, 204, 44, 173, 230, 204, 173, 53, 91, 78, 10, 8, 168, 2,
-              174, 164, 156, 16, 1, 133, 148, 15, 200, 171, 69, 101, 117, 185,
-              116, 123, 189,
-            ],
-          },
-          kernel_mmr_size: 100,
-          output_mmr_size: 200,
-          total_kernel_offset: {
-            data: [
-              230, 160, 204, 44, 173, 230, 204, 173, 53, 91, 78, 10, 8, 168, 2,
-              174, 164, 156, 16, 1, 133, 148, 15, 200, 171, 69, 101, 117, 185,
-              116, 123, 190,
-            ],
-          },
-          total_script_offset: {
-            data: [
-              230, 160, 204, 44, 173, 230, 204, 173, 53, 91, 78, 10, 8, 168, 2,
-              174, 164, 156, 16, 1, 133, 148, 15, 200, 171, 69, 101, 117, 185,
-              116, 123, 191,
-            ],
-          },
+      block_height: "64925",
+      features: 0,
+      fee: "132",
+      lock_height: "0",
+      excess: {
+        type: "Buffer" as const,
+        data: [
+          172, 63, 13, 206, 82, 192, 145, 57, 84, 68, 194, 196, 182, 243, 61, 135,
+          57, 171, 227, 227, 253, 194, 75, 210, 93, 186, 59, 177, 36, 155, 9, 80
+        ],
+      },
+      excess_sig: {
+        public_nonce: {
+          type: "Buffer" as const,
+          data: [
+            150, 152, 91, 241, 14, 196, 96, 202, 40, 170, 231, 62, 173, 202, 90, 239,
+            152, 2, 246, 182, 121, 84, 135, 115, 183, 177, 2, 233, 128, 15, 222, 78
+          ],
         },
-        body: {
-          kernels: Array(5).fill({}),
-          outputs: Array(10).fill({}),
-          inputs: Array(0).fill({}),
+        signature: {
+          type: "Buffer" as const,
+          data: [
+            234, 239, 223, 230, 221, 40, 31, 177, 98, 48, 193, 140, 134, 154, 106, 99,
+            18, 99, 174, 39, 155, 141, 107, 235, 138, 61, 246, 157, 137, 163, 88, 5
+          ],
         },
       },
+      hash: {
+        type: "Buffer" as const,
+        data: [
+          239, 153, 197, 200, 192, 2, 135, 82, 6, 27, 47, 217, 224, 75, 6, 173,
+          134, 4, 73, 131, 255, 180, 207, 92, 100, 193, 202, 252, 12, 159, 109, 193
+        ],
+      },
+      version: 0
     },
     {
-      block: {
-        header: {
-          height: 12346,
-          timestamp: 1640995260,
-          hash: {
-            data: [
-              231, 161, 205, 45, 174, 231, 205, 174, 54, 92, 79, 11, 9, 169, 3,
-              175, 165, 157, 17, 2, 134, 149, 16, 201, 172, 70, 102, 118, 186,
-              117, 124, 185,
-            ],
-          },
-          pow: { pow_algo: 2 },
-          version: 1,
-          prev_hash: {
-            data: [
-              231, 161, 205, 45, 174, 231, 205, 174, 54, 92, 79, 11, 9, 169, 3,
-              175, 165, 157, 17, 2, 134, 149, 16, 201, 172, 70, 102, 118, 186,
-              117, 124, 186,
-            ],
-          },
-          nonce: 123457,
-          output_mr: {
-            data: [
-              231, 161, 205, 45, 174, 231, 205, 174, 54, 92, 79, 11, 9, 169, 3,
-              175, 165, 157, 17, 2, 134, 149, 16, 201, 172, 70, 102, 118, 186,
-              117, 124, 187,
-            ],
-          },
-          validator_node_mr: {
-            data: [
-              231, 161, 205, 45, 174, 231, 205, 174, 54, 92, 79, 11, 9, 169, 3,
-              175, 165, 157, 17, 2, 134, 149, 16, 201, 172, 70, 102, 118, 186,
-              117, 124, 188,
-            ],
-          },
-          kernel_mr: {
-            data: [
-              231, 161, 205, 45, 174, 231, 205, 174, 54, 92, 79, 11, 9, 169, 3,
-              175, 165, 157, 17, 2, 134, 149, 16, 201, 172, 70, 102, 118, 186,
-              117, 124, 189,
-            ],
-          },
-          input_mr: {
-            data: [
-              231, 161, 205, 45, 174, 231, 205, 174, 54, 92, 79, 11, 9, 169, 3,
-              175, 165, 157, 17, 2, 134, 149, 16, 201, 172, 70, 102, 118, 186,
-              117, 124, 190,
-            ],
-          },
-          kernel_mmr_size: 101,
-          output_mmr_size: 201,
-          total_kernel_offset: {
-            data: [
-              231, 161, 205, 45, 174, 231, 205, 174, 54, 92, 79, 11, 9, 169, 3,
-              175, 165, 157, 17, 2, 134, 149, 16, 201, 172, 70, 102, 118, 186,
-              117, 124, 191,
-            ],
-          },
-          total_script_offset: {
-            data: [
-              231, 161, 205, 45, 174, 231, 205, 174, 54, 92, 79, 11, 9, 169, 3,
-              175, 165, 157, 17, 2, 134, 149, 16, 201, 172, 70, 102, 118, 186,
-              117, 124, 192,
-            ],
-          },
+      block_height: "64926",
+      features: 0,
+      fee: "145",
+      lock_height: "0",
+      excess: {
+        type: "Buffer" as const,
+        data: [
+          173, 64, 14, 207, 83, 193, 146, 58, 85, 69, 195, 197, 183, 244, 62, 136,
+          58, 172, 228, 228, 254, 195, 76, 211, 94, 187, 60, 178, 37, 156, 10, 81
+        ],
+      },
+      excess_sig: {
+        public_nonce: {
+          type: "Buffer" as const,
+          data: [
+            151, 153, 92, 242, 15, 197, 97, 203, 41, 171, 232, 63, 174, 203, 91, 240,
+            153, 3, 247, 183, 122, 85, 136, 116, 184, 178, 3, 234, 129, 16, 223, 79
+          ],
         },
-        body: {
-          kernels: Array(3).fill({}),
-          outputs: Array(8).fill({}),
-          inputs: Array(0).fill({}),
+        signature: {
+          type: "Buffer" as const,
+          data: [
+            235, 240, 224, 231, 222, 41, 32, 178, 99, 49, 194, 141, 135, 155, 107, 100,
+            19, 100, 175, 40, 156, 142, 108, 236, 139, 62, 247, 158, 138, 164, 89, 6
+          ],
         },
       },
+      hash: {
+        type: "Buffer" as const,
+        data: [
+          240, 154, 198, 201, 193, 3, 136, 83, 7, 28, 48, 218, 225, 76, 7, 174,
+          135, 5, 74, 132, 255, 181, 208, 93, 101, 194, 203, 253, 13, 160, 110, 194
+        ],
+      },
+      version: 0
     },
   ];
 
   const largeSearchResults = Array.from({ length: 25 }, (_, i) => ({
-    block: {
-      header: {
-        height: 12345 + i,
-        timestamp: 1640995200 + i * 60,
-        hash: { data: Array.from({ length: 32 }, (_, j) => 230 + i + j) },
-        pow: { pow_algo: (i % 2) + 1 },
-        version: 1,
-        prev_hash: { data: Array.from({ length: 32 }, (_, j) => 231 + i + j) },
-        nonce: 123456 + i,
-        output_mr: { data: Array.from({ length: 32 }, (_, j) => 232 + i + j) },
-        validator_node_mr: {
-          data: Array.from({ length: 32 }, (_, j) => 233 + i + j),
-        },
-        kernel_mr: { data: Array.from({ length: 32 }, (_, j) => 234 + i + j) },
-        input_mr: { data: Array.from({ length: 32 }, (_, j) => 235 + i + j) },
-        kernel_mmr_size: 100 + i,
-        output_mmr_size: 200 + i,
-        total_kernel_offset: {
-          data: Array.from({ length: 32 }, (_, j) => 236 + i + j),
-        },
-        total_script_offset: {
-          data: Array.from({ length: 32 }, (_, j) => 237 + i + j),
-        },
+    block_height: `${64925 + i}`,
+    features: i % 3,
+    fee: `${132 + i}`,
+    lock_height: "0",
+    excess: {
+      type: "Buffer" as const,
+      data: Array.from({ length: 32 }, (_, j) => 172 + i + j),
+    },
+    excess_sig: {
+      public_nonce: {
+        type: "Buffer" as const,
+        data: Array.from({ length: 32 }, (_, j) => 150 + i + j),
       },
-      body: {
-        kernels: Array(5 + i).fill({}),
-        outputs: Array(10 + i).fill({}),
-        inputs: Array(0).fill({}),
+      signature: {
+        type: "Buffer" as const,
+        data: Array.from({ length: 32 }, (_, j) => 234 + i + j),
       },
     },
+    hash: {
+      type: "Buffer" as const,
+      data: Array.from({ length: 32 }, (_, j) => 239 + i + j),
+    },
+    version: i % 2,
   }));
 
   describe('Mobile View', () => {
@@ -432,13 +345,12 @@ describe('BlockTable', () => {
 
       // Check for mobile layout elements (multiple instances for each result)
       expect(screen.getAllByText('Height')).toHaveLength(2); // One for each result
-      expect(screen.getAllByText('Timestamp')).toHaveLength(2); // Changed from "Time" to actual text
-      expect(screen.getAllByText('Proof of Work')).toHaveLength(2);
+      expect(screen.getAllByText('Hash')).toHaveLength(2);
 
       // Check for height links
       const heightLinks = screen.getAllByTestId('link');
-      expect(heightLinks[0]).toHaveAttribute('data-to', '/blocks/12345');
-      expect(heightLinks[0]).toHaveTextContent('12,345');
+      expect(heightLinks[0]).toHaveAttribute('data-to', '/blocks/64925');
+      expect(heightLinks[0]).toHaveTextContent('64,925');
     });
 
     it('should display formatted data in mobile view', () => {
@@ -448,17 +360,13 @@ describe('BlockTable', () => {
         </TestWrapper>
       );
 
-      // Check for formatted timestamps
-      expect(screen.getByText('formatted_1640995200')).toBeInTheDocument();
-      expect(screen.getByText('formatted_1640995260')).toBeInTheDocument();
+      // Check for View Block buttons
+      const viewBlockButtons = screen.getAllByText('View Block');
+      expect(viewBlockButtons).toHaveLength(2);
 
-      // Check for PoW data
-      expect(screen.getByText('pow_1')).toBeInTheDocument();
-      expect(screen.getByText('pow_2')).toBeInTheDocument();
-
-      // Check for kernel and output counts
-      expect(screen.getByText('5')).toBeInTheDocument(); // kernels
-      expect(screen.getByText('10')).toBeInTheDocument(); // outputs
+      // Check for copy to clipboard components
+      const copyComponents = screen.getAllByTestId('copy-to-clipboard');
+      expect(copyComponents).toHaveLength(2);
     });
 
     it('should handle pagination in mobile view', () => {
@@ -492,11 +400,7 @@ describe('BlockTable', () => {
 
       // Check table headers
       expect(screen.getByText('Height')).toBeInTheDocument();
-      expect(screen.getByText('Time')).toBeInTheDocument();
-      expect(screen.getByText('Proof of Work')).toBeInTheDocument();
       expect(screen.getByText('Hash')).toBeInTheDocument();
-      expect(screen.getByText('Kernels')).toBeInTheDocument();
-      expect(screen.getByText('Outputs')).toBeInTheDocument();
     });
 
     it('should render desktop block data in table format', () => {
@@ -508,23 +412,14 @@ describe('BlockTable', () => {
 
       // Check for height links
       const heightLinks = screen.getAllByTestId('link');
-      expect(heightLinks[0]).toHaveAttribute('data-to', '/blocks/12345');
-      expect(heightLinks[1]).toHaveAttribute('data-to', '/blocks/12346');
+      expect(heightLinks[0]).toHaveAttribute('data-to', '/blocks/64925');
+      expect(heightLinks[1]).toHaveAttribute('data-to', '/blocks/64926');
+      expect(heightLinks[0]).toHaveTextContent('64,925');
+      expect(heightLinks[1]).toHaveTextContent('64,926');
 
       // Check copy to clipboard components for hashes
       const copyComponents = screen.getAllByTestId('copy-to-clipboard');
-      expect(copyComponents[0]).toHaveAttribute(
-        'data-copy',
-        'hex_230,160,204,44,173,230,204,173,53,91,78,10,8,168,2,174,164,156,16,1,133,148,15,200,171,69,101,117,185,116,123,184'
-      );
-      expect(copyComponents[1]).toHaveAttribute(
-        'data-copy',
-        'hex_231,161,205,45,174,231,205,174,54,92,79,11,9,169,3,175,165,157,17,2,134,149,16,201,172,70,102,118,186,117,124,185'
-      );
-
-      // Check for formatted timestamps
-      expect(screen.getByText('formatted_1640995200')).toBeInTheDocument();
-      expect(screen.getByText('formatted_1640995260')).toBeInTheDocument();
+      expect(copyComponents).toHaveLength(2);
     });
 
     it('should display pagination controls', () => {
@@ -629,21 +524,15 @@ describe('BlockTable', () => {
         </TestWrapper>
       );
 
-      // Helper functions should be called
+      // Helper functions should be called with hash data
       expect(mockToHexString).toHaveBeenCalledWith([
-        230, 160, 204, 44, 173, 230, 204, 173, 53, 91, 78, 10, 8, 168, 2, 174,
-        164, 156, 16, 1, 133, 148, 15, 200, 171, 69, 101, 117, 185, 116, 123,
-        184,
+        239, 153, 197, 200, 192, 2, 135, 82, 6, 27, 47, 217, 224, 75, 6, 173,
+        134, 4, 73, 131, 255, 180, 207, 92, 100, 193, 202, 252, 12, 159, 109, 193
       ]);
       expect(mockToHexString).toHaveBeenCalledWith([
-        231, 161, 205, 45, 174, 231, 205, 174, 54, 92, 79, 11, 9, 169, 3, 175,
-        165, 157, 17, 2, 134, 149, 16, 201, 172, 70, 102, 118, 186, 117, 124,
-        185,
+        240, 154, 198, 201, 193, 3, 136, 83, 7, 28, 48, 218, 225, 76, 7, 174,
+        135, 5, 74, 132, 255, 181, 208, 93, 101, 194, 203, 253, 13, 160, 110, 194
       ]);
-      expect(mockFormatTimestamp).toHaveBeenCalledWith(1640995200);
-      expect(mockFormatTimestamp).toHaveBeenCalledWith(1640995260);
-      expect(mockPowCheck).toHaveBeenCalledWith('1');
-      expect(mockPowCheck).toHaveBeenCalledWith('2');
     });
   });
 
@@ -662,7 +551,7 @@ describe('BlockTable', () => {
       // Desktop layout shows data in table format without View Block buttons
       expect(screen.getAllByTestId('grid').length).toBeGreaterThan(4);
       expect(
-        screen.queryByRole('button', { name: 'View Block' })
+        screen.queryByTestId('button')
       ).not.toBeInTheDocument();
     });
 
@@ -675,15 +564,8 @@ describe('BlockTable', () => {
         </TestWrapper>
       );
 
-      const viewBlockButtons = screen.getAllByRole('button', {
-        name: 'View Block',
-      });
+      const viewBlockButtons = screen.getAllByText('View Block');
       expect(viewBlockButtons).toHaveLength(2); // One for each mock result
-      // In mobile view, actual MUI buttons are rendered, not mocked ones
-      viewBlockButtons.forEach((button) => {
-        expect(button).toHaveClass('MuiButton-outlined');
-        expect(button).toHaveClass('MuiButton-fullWidth');
-      });
     });
 
     it('should display proper component hierarchy', () => {

--- a/src/routes/KernelSearchPage.tsx
+++ b/src/routes/KernelSearchPage.tsx
@@ -20,27 +20,24 @@
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import { GradientPaper } from '@components/StyledComponents';
-import { Grid } from '@mui/material';
-import { useLocation } from 'react-router-dom';
-import { useSearchByKernel } from '@services/api/hooks/useBlocks';
-import FetchStatusCheck from '@components/FetchStatusCheck';
-import BlockTable from '@components/KernelSearch/BlockTable';
+import { GradientPaper } from "@components/StyledComponents";
+import { Grid } from "@mui/material";
+import { useLocation } from "react-router-dom";
+import { useSearchByKernel } from "@services/api/hooks/useBlocks";
+import FetchStatusCheck from "@components/FetchStatusCheck";
+import BlockTable from "@components/KernelSearch/BlockTable";
 
 function KernelsPage() {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
 
-  const noncesParams = params.get('nonces');
-  const nonces = noncesParams ? noncesParams.split(',') : [];
+  const noncesParams = params.get("nonces");
+  const nonces = noncesParams ? noncesParams.split(",") : [];
 
-  const signaturesParams = params.get('signatures');
-  const signatures = signaturesParams ? signaturesParams.split(',') : [];
+  const signaturesParams = params.get("signatures");
+  const signatures = signaturesParams ? signaturesParams.split(",") : [];
 
-  const { data, isLoading, isError, error } = useSearchByKernel(
-    nonces,
-    signatures
-  );
+  const { data, isLoading, isError, error } = useSearchByKernel(nonces, signatures);
 
   if (isLoading || isError) {
     return (
@@ -49,7 +46,7 @@ function KernelsPage() {
           <FetchStatusCheck
             isError={isError}
             isLoading={isLoading}
-            errorMessage={error?.message || 'Error retrieving data'}
+            errorMessage={error?.message || "Error retrieving data"}
           />
         </GradientPaper>
       </Grid>
@@ -57,10 +54,8 @@ function KernelsPage() {
   }
 
   if (data?.items.length === 1) {
-    const blockHeight = data.items[0].block.header.height;
-    window.location.replace(
-      `/blocks/${blockHeight}?nonce=${noncesParams}&signature=${signaturesParams}`
-    );
+    const blockHeight = data.items[0].block_height;
+    window.location.replace(`/blocks/${blockHeight}?nonce=${noncesParams}&signature=${signaturesParams}`);
   }
 
   return (

--- a/src/routes/__tests__/KernelSearchPage.test.tsx
+++ b/src/routes/__tests__/KernelSearchPage.test.tsx
@@ -248,7 +248,7 @@ describe('KernelSearchPage', () => {
 
   it('should redirect to block page when only one result is found', async () => {
     const mockData = {
-      items: [{ block: { header: { height: 12345 } } }]
+      items: [{ block_height: "12345" }]
     }
     const nonces = 'nonce1'
     const signatures = 'sig1'

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -11,6 +11,14 @@ export interface HexData {
 }
 
 /**
+ * Buffer data structure as received from Node.js Buffer serialization
+ */
+export interface BufferData {
+  type: "Buffer";
+  data: number[];
+}
+
+/**
  * API Error structure
  */
 export interface ApiError {
@@ -26,6 +34,20 @@ export interface ApiError {
  */
 export interface ProofOfWork {
   pow_algo: number; // 0=RandomX(MM), 1=SHA3x, 2=RandomX
+}
+
+export interface KernelSearchItem {
+  block_height: string;
+  features: number;
+  fee: string;
+  lock_height: string;
+  excess: HexData;
+  excess_sig: {
+    public_nonce: HexData;
+    signature: HexData;
+  };
+  hash: HexData;
+  version: number;
 }
 
 /**
@@ -204,7 +226,7 @@ export interface TimeSeriesPoint {
  * Block times chart data
  */
 export interface BlockTimesData {
-  type: 'RandomX' | 'Sha3' | 'All';
+  type: "RandomX" | "Sha3" | "All";
   targetTime: number;
   series: number[]; // Time in minutes
 }
@@ -213,7 +235,7 @@ export interface BlockTimesData {
  * Hash rates chart data
  */
 export interface HashRatesData {
-  type: 'RandomX' | 'Sha3' | 'TariRandomX';
+  type: "RandomX" | "Sha3" | "TariRandomX";
   series: TimeSeriesPoint[];
 }
 
@@ -293,9 +315,9 @@ export interface PaginatedBlockDataResponse {
 // === Search Response Structures ===
 
 /**
- * Kernel search result item
+ * Kernel search result item (legacy - for search results)
  */
-export interface KernelSearchItem {
+export interface KernelSearchResultItem {
   block_height: number;
   kernel_index: number;
   signature: HexData;
@@ -306,7 +328,7 @@ export interface KernelSearchItem {
  * Kernel search response
  */
 export interface KernelSearchResponse {
-  items: KernelSearchItem[];
+  items: KernelSearchResultItem[];
 }
 
 /**
@@ -363,13 +385,13 @@ export enum OutputType {
  * Search type enumeration
  */
 export enum SearchType {
-  BLOCK_HEIGHT = 'height',
-  BLOCK_HASH = 'hash',
-  KERNEL_SIGNATURE = 'kernel',
-  PAYMENT_REFERENCE = 'payref',
+  BLOCK_HEIGHT = "height",
+  BLOCK_HASH = "hash",
+  KERNEL_SIGNATURE = "kernel",
+  PAYMENT_REFERENCE = "payref",
 }
 
 /**
  * Block data type for pagination
  */
-export type BlockDataType = 'inputs' | 'outputs' | 'kernels';
+export type BlockDataType = "inputs" | "outputs" | "kernels";


### PR DESCRIPTION
Description
---
Updated the data being displayed in the kernel search page when searching via the url, for instance:
`https://explore.tari.com/kernel_search?nonces=96985bf10ec460ca28aae73eadca5aef9802f6b679548773b7b102e9800fde4e&signatures=eaefdfe6dd281fb16230c18c869a6a631263ae279b8d6beb8a3df69d89a35805`

Motivation and Context
---
The `kernel_search` page was broken due to changes to the api

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
